### PR TITLE
Fixed context deadline time interval. [API-705]

### DIFF
--- a/commands/map.go
+++ b/commands/map.go
@@ -61,7 +61,7 @@ func getMap(clientConfig *hazelcast.Config, mapName string) (*hazelcast.Map, err
 			log.Fatal(err)
 		}
 	}()
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if mapName == "" {
 		return nil, errors.New("map name is required")


### PR DESCRIPTION
I've fixed it as 5 seconds since the previous context was used it as 1 second, thus attempts of connecting to Hazelcast Cloud have always failed.