### PR TITLE
Change map name shorthand flag

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -54,7 +54,7 @@ func Execute() {
 func decorateRootCommand(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", fmt.Sprintf("config file (default is %s)", internal.DefautConfigPath()))
 	cmd.PersistentFlags().StringVarP(&addresses, "address", "a", "", "addresses of the instances in the cluster.")
-	cmd.PersistentFlags().StringVarP(&cluster, "cluster-name", "n", "", "name of the cluster that contains the instances.")
+	cmd.PersistentFlags().StringVarP(&cluster, "cluster-name", "", "", "name of the cluster that contains the instances.")
 	cmd.PersistentFlags().StringVar(&token, "cloud-token", "", "your Hazelcast Cloud token.")
 	cmd.CompletionOptions.DisableDefaultCmd = true
 

--- a/commands/types/map/map.go
+++ b/commands/types/map/map.go
@@ -84,7 +84,7 @@ func getMap(clientConfig *hazelcast.Config, mapName string) (result *hazelcast.M
 }
 
 func decorateCommandWithMapNameFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&mapName, "name", "m", "", "specify the map name")
+	cmd.Flags().StringVarP(&mapName, "name", "n", "", "specify the map name")
 	cmd.MarkFlagRequired("name")
 }
 


### PR DESCRIPTION
- change shorthand flag for map name from "-m" to "-n"
- remove shorthand for "--cluster-name" to prevent flag collision