### PR TITLE
Demo fixes [API-1117]

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -37,7 +37,8 @@ var (
 		Use:   "hzc {cluster | help | map} [--address address | --cloud-token token | --cluster-name name | --config config]",
 		Short: "Hazelcast command-line client",
 		Long:  "Hazelcast command-line client connects your command-line to a Hazelcast cluster",
-		Example: "`hzc map --name my-map put --key hello --value world` - put entry into map directly\n" +
+		Example: "`hzc` - starts an interactive shell 🚀\n" +
+			"`hzc map --name my-map put --key hello --value world` - put entry into map directly\n" +
 			"`hzc help` - print help",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if _, err := internal.MakeConfig(); err != nil {
@@ -116,6 +117,8 @@ func ExecuteInteractive() {
 	var flagsToExclude []string
 	RootCmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
 		flagsToExclude = append(flagsToExclude, flag.Name)
+		// Mark hidden to exclude from help text in interactive mode.
+		flag.Hidden = true
 	})
 	flagsToExclude = append(flagsToExclude, "help")
 	advancedPrompt.FlagsToExclude = flagsToExclude

--- a/commands/types/map/mapget.go
+++ b/commands/types/map/mapget.go
@@ -57,7 +57,7 @@ var mapGetCmd = &cobra.Command{
 		if value != nil {
 			switch v := value.(type) {
 			case serialization.JSON:
-				if err := quick.Highlight(os.Stdout, v.String(),
+				if err := quick.Highlight(os.Stdout, fmt.Sprintln(v.String()),
 					"json", "terminal", "tango"); err != nil {
 					fmt.Println(v.String())
 				}

--- a/internal/cobraprompt/prompt.go
+++ b/internal/cobraprompt/prompt.go
@@ -12,6 +12,8 @@ import (
 	"github.com/google/shlex"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/hazelcast/hazelcast-commandline-client/internal"
 )
 
 // DynamicSuggestionsAnnotation for dynamic suggestions.
@@ -156,34 +158,8 @@ func findSuggestions(co *CobraPrompt, d *prompt.Document) []prompt.Suggest {
 	if found, _, err := command.Find(args); err == nil {
 		command = found
 	}
-	var suggestions []prompt.Suggest
-	persistFlagValues, err := command.Flags().GetBool(PersistFlagValuesFlag)
-	if err != nil {
-		fmt.Println("cannot parse persist flag err: ", err)
-	}
-	addFlags := func(flag *pflag.Flag) {
-		if flag.Changed && !persistFlagValues {
-			flag.Value.Set(flag.DefValue)
-		}
-		if flag.Hidden && !co.ShowHiddenFlags {
-			return
-		}
-		if stringInSlice(co.FlagsToExclude, flag.Name) {
-			return
-		}
-		flagUsage := "--" + flag.Name
-		if strings.HasPrefix(d.GetWordBeforeCursor(), "--") {
-			suggestions = append(suggestions, prompt.Suggest{Text: flagUsage, Description: flag.Usage})
-		} else if (co.SuggestFlagsWithoutDash && d.GetWordBeforeCursor() == "") || strings.HasPrefix(d.GetWordBeforeCursor(), "-") {
-			if flag.Shorthand != "" {
-				suggestions = append(suggestions, prompt.Suggest{Text: fmt.Sprintf("-%s", flag.Shorthand), Description: fmt.Sprintf("or %s %s", flagUsage, flag.Usage)})
-				return
-			}
-			suggestions = append(suggestions, prompt.Suggest{Text: flagUsage, Description: flag.Usage})
-		}
-	}
-	command.LocalFlags().VisitAll(addFlags)
-	command.InheritedFlags().VisitAll(addFlags)
+	wordBeforeCursor := d.GetWordBeforeCursor()
+	suggestions := traverseForFlagSuggestions(wordBeforeCursor, args, co, command)
 	if command.HasAvailableSubCommands() {
 		for _, c := range command.Commands() {
 			if !c.Hidden && !co.ShowHiddenCommands {
@@ -198,7 +174,42 @@ func findSuggestions(co *CobraPrompt, d *prompt.Document) []prompt.Suggest {
 	if co.DynamicSuggestionsFunc != nil && annotation != "" {
 		suggestions = append(suggestions, co.DynamicSuggestionsFunc(annotation, d)...)
 	}
-	return prompt.FilterHasPrefix(suggestions, d.GetWordBeforeCursor(), true)
+	return prompt.FilterHasPrefix(suggestions, wordBeforeCursor, true)
+}
+
+func traverseForFlagSuggestions(wordBeforeCursor string, words []string, co *CobraPrompt, command *cobra.Command) []prompt.Suggest {
+	var suggestions []prompt.Suggest
+	noWordTyped := wordBeforeCursor == ""
+	dashPrefix := strings.HasPrefix(wordBeforeCursor, "-")
+	if !noWordTyped && !dashPrefix {
+		// no flag prefix
+		return suggestions
+	}
+	addFlags := func(flag *pflag.Flag) {
+		if flag.Hidden && !co.ShowHiddenFlags {
+			return
+		}
+		if stringInSlice(co.FlagsToExclude, flag.Name) {
+			return
+		}
+		flagUsage := "--" + flag.Name
+		// Check if flag is already used in the command
+		if (flag.Shorthand != "" && internal.IsOneOf(words, "-"+flag.Shorthand, true)) ||
+			internal.IsOneOf(words, flagUsage, true) {
+			return
+		}
+		if strings.HasPrefix(wordBeforeCursor, "--") {
+			suggestions = append(suggestions, prompt.Suggest{Text: flagUsage, Description: flag.Usage})
+		} else if (noWordTyped || dashPrefix) && flag.Shorthand != "" {
+			flagShort := fmt.Sprintf("-%s", flag.Shorthand)
+			suggestions = append(suggestions, prompt.Suggest{Text: flagShort, Description: fmt.Sprintf("or %s %s", flagUsage, flag.Usage)})
+		} else {
+			suggestions = append(suggestions, prompt.Suggest{Text: flagUsage, Description: flag.Usage})
+		}
+	}
+	command.LocalFlags().VisitAll(addFlags)
+	command.InheritedFlags().VisitAll(addFlags)
+	return suggestions
 }
 
 func stringInSlice(slice []string, str string) bool {

--- a/internal/cobraprompt/prompt.go
+++ b/internal/cobraprompt/prompt.go
@@ -153,12 +153,16 @@ func RegisterPersistFlag(co *cobra.Command) {
 }
 
 func findSuggestions(co *CobraPrompt, d *prompt.Document) []prompt.Suggest {
-	command := co.RootCmd
-	args := strings.Fields(d.CurrentLine())
-	if found, _, err := command.Find(args); err == nil {
-		command = found
+	upToCursor := d.CurrentLineBeforeCursor()
+	// use line before cursor for command suggestion
+	bArgs := strings.Fields(upToCursor)
+	command, _, err := co.RootCmd.Find(bArgs)
+	if err != nil && strings.Contains(upToCursor, " ") {
+		return nil
 	}
 	wordBeforeCursor := d.GetWordBeforeCursor()
+	// use whole line for flag suggestions
+	args := strings.Fields(d.CurrentLine())
 	suggestions := traverseForFlagSuggestions(wordBeforeCursor, args, co, command)
 	if command.HasAvailableSubCommands() {
 		for _, c := range command.Commands() {

--- a/internal/util.go
+++ b/internal/util.go
@@ -1,0 +1,17 @@
+package internal
+
+import "strings"
+
+func IsOneOf(list []string, s string, caseSensitive bool) bool {
+	op := func(s string) string { return s }
+	if !caseSensitive {
+		op = strings.ToLower
+	}
+	s = op(s)
+	for _, e := range list {
+		if s == op(e) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- Add interactive shell example to “example”
- Hide persistent flags such as —cluster-token in help text in interactive mode
- Fix output for “map get —value-type json”
- Exclude already used flags from suggestions
- Partially fix suggestion when input is not valid