### PR TITLE
[EASY] change ghExtractTag for newer release tags

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,7 @@ HZCLI_HOME="$HOME/.local/share/hz-cli"
 
 ghExtractTag() {
   tagUrl=$(curl "https://github.com/$1/releases/latest" -s -L -I -o /dev/null -w '%{url_effective}')
-  printf "%s\n" "${tagUrl##*v}"
+  printf "%s\n" "${tagUrl##*tag/v}"
 }
 
 bin_id=""


### PR DESCRIPTION
Currently installation script cannot parse release tag correctly. To reproduce to error and fix, you can try
```
x="https://github.com/hazelcast/hazelcast-commandline-client/releases/tag/v0.1.0-preview.1"
echo ${x##*v}
echo ${x##*tag/v}
```
on bash terminal