### PR TITLE
Fix Ctrl-left behavior [API-1208]

### DIFF
--- a/internal/cobraprompt/prompt.go
+++ b/internal/cobraprompt/prompt.go
@@ -106,10 +106,10 @@ func (co CobraPrompt) Run(ctx context.Context, root *cobra.Command, cnfg *hazelc
 			exitPromptSafely()
 		},
 	}), goprompt.OptionAddKeyBind(goprompt.KeyBind{
-		Key: goprompt.Key(86),
+		Key: goprompt.ControlLeft,
 		Fn: func(b *goprompt.Buffer) {
-			to := b.Document().FindEndOfCurrentWordWithSpace()
-			b.CursorRight(to)
+			to := b.Document().FindPreviousWordStart()
+			b.CursorLeft(to)
 		},
 	}), goprompt.OptionAddKeyBind(goprompt.KeyBind{
 		Key: goprompt.ControlRight,

--- a/internal/go-prompt/document.go
+++ b/internal/go-prompt/document.go
@@ -2,6 +2,7 @@ package prompt
 
 import (
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/mattn/go-runewidth"
@@ -196,6 +197,23 @@ func (d *Document) FindEndOfCurrentWord() int {
 		return i
 	}
 	return len(x)
+}
+
+func (d *Document) FindPreviousWordStart() int {
+	x := d.TextBeforeCursor()
+	var i int
+	for i = len(x) - 1; i > 0; i-- {
+		if !unicode.IsSpace(rune(x[i])) {
+			break
+		}
+	}
+	for ; i > 0; i-- {
+		if unicode.IsSpace(rune(x[i])) {
+			i++
+			break
+		}
+	}
+	return d.cursorPosition - i
 }
 
 // FindEndOfCurrentWordWithSpace is almost the same as FindEndOfCurrentWord.

--- a/internal/go-prompt/document.go
+++ b/internal/go-prompt/document.go
@@ -199,8 +199,12 @@ func (d *Document) FindEndOfCurrentWord() int {
 	return len(x)
 }
 
+// FindPreviousWordStart returns the distance to first end of word or start of word
 func (d *Document) FindPreviousWordStart() int {
 	x := d.TextBeforeCursor()
+	if x == "" {
+		return 0
+	}
 	var i int
 	for i = len(x) - 1; i > 0; i-- {
 		if !unicode.IsSpace(rune(x[i])) {

--- a/internal/go-prompt/document_test.go
+++ b/internal/go-prompt/document_test.go
@@ -1,0 +1,78 @@
+package prompt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocument_FindPreviousWordStart(t *testing.T) {
+	testCases := []struct {
+		doc         Document
+		charsToLeft int
+	}{
+		{
+			doc: Document{
+				Text:           "",
+				cursorPosition: 0,
+			},
+			charsToLeft: 0,
+		},
+		{
+			doc: Document{
+				Text:           "abc",
+				cursorPosition: 0,
+			},
+			charsToLeft: 0,
+		},
+		{
+			doc: Document{
+				Text:           "abc",
+				cursorPosition: 1,
+			},
+			charsToLeft: 1,
+		},
+		{
+			doc: Document{
+				Text:           "abc",
+				cursorPosition: 2,
+			},
+			charsToLeft: 2,
+		},
+		{
+			doc: Document{
+				Text:           "abc ",
+				cursorPosition: 3,
+			},
+			charsToLeft: 3,
+		},
+		{
+			doc: Document{
+				Text:           "abc  ",
+				cursorPosition: 4,
+			},
+			charsToLeft: 4,
+		},
+		{
+			doc: Document{
+				Text:           "abc x",
+				cursorPosition: 4,
+			},
+			charsToLeft: 4,
+		},
+		{
+			doc: Document{
+				Text:           "abc xw",
+				cursorPosition: 5,
+			},
+			charsToLeft: 1,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			assert.Equal(t, tc.charsToLeft, tc.doc.FindPreviousWordStart())
+		})
+	}
+}


### PR DESCRIPTION
We observed that ctrl - left did not work as expected. This work tries to fix that. I confirmed that it looks good on:
- zsh with some tweaks to send correct char sequences for ctrl+arrow keys. By default it does not use readline() under the hood. This fix is necessary to capture those.

Dear reviewers, if you have an environment other than this, please also try and see if it is fixed. Thanks!