### PR TITLE
Subset of primitive types support for serialization [API-1179]

### DIFF
--- a/internal/conversion.go
+++ b/internal/conversion.go
@@ -1,78 +1,81 @@
 package internal
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/hazelcast/hazelcast-go-client/serialization"
 )
 
 // supported types
 const (
-	String  = "string"
-	Boolean = "boolean"
-	JSON    = "json"
-	Int8    = "int8"
-	Int16   = "int16"
-	Int32   = "int32"
-	Int64   = "int64"
-	Float32 = "float32"
-	Float64 = "float64"
+	TypeNameString  = "string"
+	TypeNameBoolean = "boolean"
+	TypeNameJSON    = "json"
+	TypeNameInt8    = "int8"
+	TypeNameInt16   = "int16"
+	TypeNameInt32   = "int32"
+	TypeNameInt64   = "int64"
+	TypeNameFloat32 = "float32"
+	TypeNameFloat64 = "float64"
 )
 
-var SupportedTypes = []string{
-	String,
-	Boolean,
-	JSON,
-	Int8,
-	Int16,
-	Int32,
-	Int64,
-	Float32,
-	Float64,
+var SupportedTypeNames = []string{
+	TypeNameString,
+	TypeNameBoolean,
+	TypeNameJSON,
+	TypeNameInt8,
+	TypeNameInt16,
+	TypeNameInt32,
+	TypeNameInt64,
+	TypeNameFloat32,
+	TypeNameFloat64,
 }
 
 func ConvertString(value, valueType string) (interface{}, error) {
 	var (
-		convertedValue interface{}
-		err            error
-	)
-	var (
-		intermediateInt   int64
-		intermediateFloat float64
+		cv  interface{}
+		err error
+		i   int64
+		f   float64
 	)
 	switch valueType {
-	case String:
-		convertedValue = value
-	case Boolean:
-		convertedValue, err = strconv.ParseBool(value)
-	case JSON:
-		convertedValue = serialization.JSON(value)
-	case Int8:
-		intermediateInt, err = strconv.ParseInt(value, 10, 8)
-		convertedValue = int8(intermediateInt)
-	case Int16:
-		intermediateInt, err = strconv.ParseInt(value, 10, 16)
-		convertedValue = int16(intermediateInt)
-	case Int32:
-		intermediateInt, err = strconv.ParseInt(value, 10, 32)
-		convertedValue = int32(intermediateInt)
-	case Int64:
-		convertedValue, err = strconv.ParseInt(value, 10, 64)
-	case Float32:
-		intermediateFloat, err = strconv.ParseFloat(value, 32)
-		convertedValue = float32(intermediateFloat)
-	case Float64:
-		convertedValue, err = strconv.ParseFloat(value, 64)
-	default:
-		err = fmt.Errorf("unknown type, provide one of %v", SupportedTypes)
-	}
-	if numErr, ok := err.(*strconv.NumError); ok {
-		if numErr.Err == strconv.ErrSyntax {
-			err = fmt.Errorf(`can not convert "%s" to %s, unknown syntax`, value, valueType)
-		} else if numErr.Err == strconv.ErrRange {
-			err = fmt.Errorf(`%s can not be represented with specified bit number (max val:%v)`, value, convertedValue)
+	case TypeNameString:
+		cv = value
+	case TypeNameBoolean:
+		cv, err = strconv.ParseBool(value)
+	case TypeNameJSON:
+		if !json.Valid([]byte(value)) {
+			err = errors.New("malformed JSON string")
+			break
 		}
+		cv = serialization.JSON(value)
+	case TypeNameInt8:
+		i, err = strconv.ParseInt(value, 10, 8)
+		cv = int8(i)
+	case TypeNameInt16:
+		i, err = strconv.ParseInt(value, 10, 16)
+		cv = int16(i)
+	case TypeNameInt32:
+		i, err = strconv.ParseInt(value, 10, 32)
+		cv = int32(i)
+	case TypeNameInt64:
+		cv, err = strconv.ParseInt(value, 10, 64)
+	case TypeNameFloat32:
+		f, err = strconv.ParseFloat(value, 32)
+		cv = float32(f)
+	case TypeNameFloat64:
+		cv, err = strconv.ParseFloat(value, 64)
+	default:
+		err = fmt.Errorf("unknown type, provide one of %v", strings.Join(SupportedTypeNames, ","))
 	}
-	return convertedValue, err
+	if errors.Is(err, strconv.ErrSyntax) {
+		err = fmt.Errorf(`can not convert "%s" to %s, unknown syntax`, value, valueType)
+	} else if errors.Is(err, strconv.ErrRange) {
+		err = fmt.Errorf(`%s can not be represented with specified bit number (max val:%v)`, value, cv)
+	}
+	return cv, err
 }

--- a/internal/conversion.go
+++ b/internal/conversion.go
@@ -1,0 +1,78 @@
+package internal
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hazelcast/hazelcast-go-client/serialization"
+)
+
+// supported types
+const (
+	String  = "string"
+	Boolean = "boolean"
+	JSON    = "json"
+	Int8    = "int8"
+	Int16   = "int16"
+	Int32   = "int32"
+	Int64   = "int64"
+	Float32 = "float32"
+	Float64 = "float64"
+)
+
+var SupportedTypes = []string{
+	String,
+	Boolean,
+	JSON,
+	Int8,
+	Int16,
+	Int32,
+	Int64,
+	Float32,
+	Float64,
+}
+
+func ConvertString(value, valueType string) (interface{}, error) {
+	var (
+		convertedValue interface{}
+		err            error
+	)
+	var (
+		intermediateInt   int64
+		intermediateFloat float64
+	)
+	switch valueType {
+	case String:
+		convertedValue = value
+	case Boolean:
+		convertedValue, err = strconv.ParseBool(value)
+	case JSON:
+		convertedValue = serialization.JSON(value)
+	case Int8:
+		intermediateInt, err = strconv.ParseInt(value, 10, 8)
+		convertedValue = int8(intermediateInt)
+	case Int16:
+		intermediateInt, err = strconv.ParseInt(value, 10, 16)
+		convertedValue = int16(intermediateInt)
+	case Int32:
+		intermediateInt, err = strconv.ParseInt(value, 10, 32)
+		convertedValue = int32(intermediateInt)
+	case Int64:
+		convertedValue, err = strconv.ParseInt(value, 10, 64)
+	case Float32:
+		intermediateFloat, err = strconv.ParseFloat(value, 32)
+		convertedValue = float32(intermediateFloat)
+	case Float64:
+		convertedValue, err = strconv.ParseFloat(value, 64)
+	default:
+		err = fmt.Errorf("unknown type, provide one of %v", SupportedTypes)
+	}
+	if numErr, ok := err.(*strconv.NumError); ok {
+		if numErr.Err == strconv.ErrSyntax {
+			err = fmt.Errorf(`can not convert "%s" to %s, unknown syntax`, value, valueType)
+		} else if numErr.Err == strconv.ErrRange {
+			err = fmt.Errorf(`%s can not be represented with specified bit number (max val:%v)`, value, convertedValue)
+		}
+	}
+	return convertedValue, err
+}

--- a/types/mapcmd/map.go
+++ b/types/mapcmd/map.go
@@ -18,6 +18,7 @@ package mapcmd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/spf13/cobra"
@@ -112,10 +113,10 @@ func decorateCommandWithMapNameFlags(cmd *cobra.Command, mapName *string) {
 func decorateCommandWithKeyFlags(cmd *cobra.Command, mapKey, mapKeyType *string) {
 	flags := cmd.Flags()
 	flags.StringVarP(mapKey, "key", "k", "", "key of the map")
-	flags.StringVarP(mapKeyType, "key-type", "", "string", "type of the key, one of: string, json, int(8,16,32,64), float(32,64)")
+	flags.StringVarP(mapKeyType, "key-type", "", "string", fmt.Sprintf("type of the key, one of: %s", strings.Join(internal.SupportedTypeNames, ",")))
 	cmd.MarkFlagRequired("key")
 	cmd.RegisterFlagCompletionFunc("key-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return internal.SupportedTypes, cobra.ShellCompDirectiveDefault
+		return internal.SupportedTypeNames, cobra.ShellCompDirectiveDefault
 	})
 }
 
@@ -123,8 +124,8 @@ func decorateCommandWithValueFlags(cmd *cobra.Command, mapValue, mapValueFile, m
 	flags := cmd.Flags()
 	flags.StringVarP(mapValue, "value", "v", "", "value of the map")
 	flags.StringVarP(mapValueFile, "value-file", "f", "", `path to the file that contains the value. Use "-" (dash) to read from stdin`)
-	flags.StringVarP(mapValueType, "value-type", "t", "string", "type of the value, one of: string, json, int(8,16,32,64), float(32,64)")
+	flags.StringVarP(mapValueType, "value-type", "t", "string", fmt.Sprintf("type of the value, one of: %s", strings.Join(internal.SupportedTypeNames, ",")))
 	cmd.RegisterFlagCompletionFunc("value-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return internal.SupportedTypes, cobra.ShellCompDirectiveDefault
+		return internal.SupportedTypeNames, cobra.ShellCompDirectiveDefault
 	})
 }

--- a/types/mapcmd/map.go
+++ b/types/mapcmd/map.go
@@ -74,7 +74,7 @@ func getMap(ctx context.Context, clientConfig *hazelcast.Config, mapName string)
 	return
 }
 
-const MapUseExample = "map use m1          # sets the default map name to m1 unless set explicitly"
+const MapUseExample = "map use m1    # sets the default map name to m1 unless set explicitly"
 
 func NewUse() *cobra.Command {
 	cmd := &cobra.Command{
@@ -109,17 +109,22 @@ func decorateCommandWithMapNameFlags(cmd *cobra.Command, mapName *string) {
 	cmd.MarkFlagRequired("name")
 }
 
-func decorateCommandWithKeyFlags(cmd *cobra.Command, mapKey *string) {
-	cmd.Flags().StringVarP(mapKey, "key", "k", "", "key of the map")
+func decorateCommandWithKeyFlags(cmd *cobra.Command, mapKey, mapKeyType *string) {
+	flags := cmd.Flags()
+	flags.StringVarP(mapKey, "key", "k", "", "key of the map")
+	flags.StringVarP(mapKeyType, "key-type", "", "string", "type of the key, one of: string, json, int(8,16,32,64), float(32,64)")
 	cmd.MarkFlagRequired("key")
+	cmd.RegisterFlagCompletionFunc("key-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return internal.SupportedTypes, cobra.ShellCompDirectiveDefault
+	})
 }
 
 func decorateCommandWithValueFlags(cmd *cobra.Command, mapValue, mapValueFile, mapValueType *string) {
 	flags := cmd.Flags()
 	flags.StringVarP(mapValue, "value", "v", "", "value of the map")
 	flags.StringVarP(mapValueFile, "value-file", "f", "", `path to the file that contains the value. Use "-" (dash) to read from stdin`)
-	flags.StringVarP(mapValueType, "value-type", "t", "string", "type of the value, one of: string, json")
+	flags.StringVarP(mapValueType, "value-type", "t", "string", "type of the value, one of: string, json, int(8,16,32,64), float(32,64)")
 	cmd.RegisterFlagCompletionFunc("value-type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"json", "string"}, cobra.ShellCompDirectiveDefault
+		return internal.SupportedTypes, cobra.ShellCompDirectiveDefault
 	})
 }

--- a/types/mapcmd/mapget.go
+++ b/types/mapcmd/mapget.go
@@ -26,24 +26,30 @@ import (
 	"github.com/spf13/cobra"
 
 	hzcerrors "github.com/hazelcast/hazelcast-commandline-client/errors"
+	"github.com/hazelcast/hazelcast-commandline-client/internal"
 )
 
-const MapGetExample = `map get --key hello --name myMap`
+const MapGetExample = `map get --key hello --name myMap
+map get --key-type int16 --key 2012 --name yearbook`
 
 func NewGet(config *hazelcast.Config) *cobra.Command {
-	var mapName, mapKey string
+	var mapName, mapKey, mapKeyType string
 	cmd := &cobra.Command{
 		Use:     "get [--name mapname | --key keyname]",
 		Short:   "Get from map",
 		Example: MapGetExample,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			key, err := internal.ConvertString(mapKey, mapKeyType)
+			if err != nil {
+				return hzcerrors.NewLoggableError(err, "Conversion error on key %s to type %s", mapKey, mapKeyType)
+			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), time.Second*3)
 			defer cancel()
 			m, err := getMap(ctx, config, mapName)
 			if err != nil {
 				return err
 			}
-			value, err := m.Get(ctx, mapKey)
+			value, err := m.Get(ctx, key)
 			if err != nil {
 				isCloudCluster := config.Cluster.Cloud.Enabled
 				if networkErrMsg, handled := hzcerrors.TranslateNetworkError(err, isCloudCluster); handled {
@@ -68,6 +74,6 @@ func NewGet(config *hazelcast.Config) *cobra.Command {
 		},
 	}
 	decorateCommandWithMapNameFlags(cmd, &mapName)
-	decorateCommandWithKeyFlags(cmd, &mapKey)
+	decorateCommandWithKeyFlags(cmd, &mapKey, &mapKeyType)
 	return cmd
 }


### PR DESCRIPTION
Introduce basic primitive types for serialization for map keys and values for types

Integers (8, 16, 32, 64)
Boolean
Floats (32, 64)