### PR TITLE
mark "insecureskipverify" example as unsafe in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ You can use the following configuration file to enable SSL support:
 ssl:
     enabled: true
     servername: "HOSTNAME-FOR-SERVER"
-    # or: insecureskipverify: true
+    # [UNSAFE] or: insecureskipverify: true
 hazelcast:
   cluster:
     security:


### PR DESCRIPTION
"insecureskipverify" should never be used in production. There is always other options and we need to mark it as unsafe