### PR TITLE
version sub-command added. [API-1456]

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ builds:
       - CGO_ENABLED=0
     ldflags:
       - "-X github.com/hazelcast/hazelcast-go-client/internal.ClientVersion={{.Version}} -X github.com/hazelcast/hazelcast-commandline-client/internal.GitCommit={{.Commit}} -X github.com/hazelcast/hazelcast-go-client/internal.ClientType=CLC"
+      - "-X github.com/hazelcast/hazelcast-commandline-client/internal.ClientVersion={{.Version}}"
     binary: hzc
     goos:
       - darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - "-X github.com/hazelcast/hazelcast-go-client/internal.ClientVersion={{.Version}} -X github.com/hazelcast/hazelcast-go-client/internal.ClientType=CLC"
+      - "-X github.com/hazelcast/hazelcast-go-client/internal.ClientVersion={{.Version}} -X github.com/hazelcast/hazelcast-commandline-client/internal.GitCommit={{.Commit}} -X github.com/hazelcast/hazelcast-go-client/internal.ClientType=CLC"
     binary: hzc
     goos:
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 .PHONY: build generate-completion test test-cover view-cover
 
 TAG=$(shell git describe --tags 2> /dev/null || echo unknown)
+GIT_COMMIT=$(shell git rev-parse HEAD 2> /dev/null || echo unknown)
 CLIENT_TYPE="CLC"
-LDFLAGS="-X 'github.com/hazelcast/hazelcast-go-client/internal.ClientType=$(CLIENT_TYPE)' -X 'github.com/hazelcast/hazelcast-go-client/internal.ClientVersion=$(TAG)'"
+LDFLAGS="-X 'github.com/hazelcast/hazelcast-go-client/internal.ClientType=$(CLIENT_TYPE)' -X 'github.com/hazelcast/hazelcast-commandline-client/internal.GitCommit=$(GIT_COMMIT)' -X 'github.com/hazelcast/hazelcast-go-client/internal.ClientVersion=$(TAG)'"
 TEST_FLAGS ?= -v -count 1
 COVERAGE_OUT = coverage.out
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
 .PHONY: build generate-completion test test-cover view-cover
 
-TAG=$(shell git describe --tags 2> /dev/null || echo unknown)
 GIT_COMMIT=$(shell git rev-parse HEAD 2> /dev/null || echo unknown)
-CLC_VERSION=$(shell git tag | sort -V | tail -1 2> /dev/null || echo unknown)
-CLIENT_TYPE="CLC"
-LDFLAGS="-X 'github.com/hazelcast/hazelcast-go-client/internal.ClientType=$(CLIENT_TYPE)' -X 'github.com/hazelcast/hazelcast-commandline-client/internal.GitCommit=$(GIT_COMMIT)' -X 'github.com/hazelcast/hazelcast-go-client/internal.ClientVersion=$(TAG)' -X 'github.com/hazelcast/hazelcast-commandline-client/internal.ClientVersion=$(CLC_VERSION)'"
+CLC_VERSION=$(shell git describe --tags $(git rev-list --tags --max-count=1) || echo UNKNOWN)
+LDFLAGS="-X 'github.com/hazelcast/hazelcast-go-client/internal.ClientType=CLC' -X 'github.com/hazelcast/hazelcast-commandline-client/internal.GitCommit=$(GIT_COMMIT)' -X 'github.com/hazelcast/hazelcast-commandline-client/internal.ClientVersion=$(CLC_VERSION)' -X 'github.com/hazelcast/hazelcast-go-client/internal.ClientVersion=$(CLC_VERSION)'"
 TEST_FLAGS ?= -v -count 1
 COVERAGE_OUT = coverage.out
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 
 TAG=$(shell git describe --tags 2> /dev/null || echo unknown)
 GIT_COMMIT=$(shell git rev-parse HEAD 2> /dev/null || echo unknown)
+CLC_VERSION=$(shell git tag | sort -V | tail -1 2> /dev/null || echo unknown)
 CLIENT_TYPE="CLC"
-LDFLAGS="-X 'github.com/hazelcast/hazelcast-go-client/internal.ClientType=$(CLIENT_TYPE)' -X 'github.com/hazelcast/hazelcast-commandline-client/internal.GitCommit=$(GIT_COMMIT)' -X 'github.com/hazelcast/hazelcast-go-client/internal.ClientVersion=$(TAG)'"
+LDFLAGS="-X 'github.com/hazelcast/hazelcast-go-client/internal.ClientType=$(CLIENT_TYPE)' -X 'github.com/hazelcast/hazelcast-commandline-client/internal.GitCommit=$(GIT_COMMIT)' -X 'github.com/hazelcast/hazelcast-go-client/internal.ClientVersion=$(TAG)' -X 'github.com/hazelcast/hazelcast-commandline-client/internal.ClientVersion=$(CLC_VERSION)'"
 TEST_FLAGS ?= -v -count 1
 COVERAGE_OUT = coverage.out
 

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -16,6 +16,7 @@
 ** xref:hzc-cluster.adoc[]
 ** xref:hzc-map.adoc[]
 ** xref:hzc-sql.adoc[]
+** xref:hzc-version.adoc[]
 * xref:keyboard-shortcuts.adoc[]
 
 .Release Notes

--- a/docs/modules/ROOT/pages/clc-commands.adoc
+++ b/docs/modules/ROOT/pages/clc-commands.adoc
@@ -18,4 +18,7 @@
 |xref:hzc-sql.adoc[hzc sql]
 |Execute SQL queries.
 
+|xref:hzc-version.adoc[hzc version]
+|Get version information.
+
 |===

--- a/docs/modules/ROOT/pages/hzc-version.adoc
+++ b/docs/modules/ROOT/pages/hzc-version.adoc
@@ -1,0 +1,18 @@
+= hzc version
+:description: Prints all the version information about CLC.
+
+{description}
+
+Version command outputs information about the followings:
+
+* Hazelcast Commandline Client Version
+* Latest Git commit hash to CLC
+* Hazelcast Go Client Version
+* Go Version
+
+Example usage:
+
+[source,bash]
+----
+hzc version
+----

--- a/internal/connect.go
+++ b/internal/connect.go
@@ -36,8 +36,10 @@ var InvalidStateErr = errors.New("invalid new state")
 
 //todo add protection for concurrent access
 var (
-	client    *hazelcast.Client
-	sqlDriver *sql.DB
+	client        *hazelcast.Client
+	sqlDriver     *sql.DB
+	GitCommit     string
+	ClientVersion = "v1.0.0-beta1"
 )
 
 type RESTCall struct {

--- a/internal/connect.go
+++ b/internal/connect.go
@@ -39,7 +39,7 @@ var (
 	client        *hazelcast.Client
 	sqlDriver     *sql.DB
 	GitCommit     string
-	ClientVersion = "v1.0.0-beta1"
+	ClientVersion string
 )
 
 type RESTCall struct {

--- a/rootcmd/root.go
+++ b/rootcmd/root.go
@@ -18,6 +18,7 @@ package rootcmd
 import (
 	"errors"
 	"fmt"
+	"github.com/hazelcast/hazelcast-commandline-client/versioncmd"
 	"os"
 	"strings"
 
@@ -35,7 +36,7 @@ import (
 func New(cnfg *hazelcast.Config) (*cobra.Command, *config.GlobalFlagValues) {
 	var flags config.GlobalFlagValues
 	root := &cobra.Command{
-		Use:   "hzc {cluster | map | sql | help} [--address address | --cloud-token token | --cluster-name name | --config config]",
+		Use:   "hzc {cluster | map | sql | version | help} [--address address | --cloud-token token | --cluster-name name | --config config]",
 		Short: "Hazelcast command-line client",
 		Long:  "Hazelcast command-line client connects your command-line to a Hazelcast cluster",
 		Example: `hzc # starts an interactive shell 🚀
@@ -70,6 +71,7 @@ func subCommands(config *hazelcast.Config) []*cobra.Command {
 		clustercmd.New(config),
 		mapcmd.New(config),
 		sqlcmd.New(config),
+		versioncmd.New(),
 	}
 	fds := []fakeDoor.FakeDoor{
 		{Name: "List", IssueNum: 48},

--- a/versioncmd/version.go
+++ b/versioncmd/version.go
@@ -1,0 +1,24 @@
+package versioncmd
+
+import (
+	"fmt"
+	"github.com/hazelcast/hazelcast-commandline-client/internal"
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/spf13/cobra"
+	"runtime"
+)
+
+func New() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "version",
+		Short: "Version and build information",
+		Long:  `Version and build information including the Go version, Hazelcast Go Client version and latest Git commit hash.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Hazelcast Command Line Client Version: %s\n", internal.ClientVersion)
+			fmt.Printf("Latest Git Commit Hash: %s\n", internal.GitCommit)
+			fmt.Printf("Hazelcast Go Client Version: %s\n", hazelcast.ClientVersion)
+			fmt.Printf("Go Version: %s\n", runtime.Version())
+		},
+	}
+	return &cmd
+}


### PR DESCRIPTION
CLC prints followings when `version` command called:
- Command Line Client Version
- Latest Git commit hash
- Hazelcast Go Client Version
- Go Version

The CLC version is hard coded inside the `internal` package, similar to Go Client. Others are aimed to change dynamically at build and runtime. Since we created a new command, a new folder (`versioncmd`) has been created to accomplish `subCommand` pattern. 