### PR TITLE
Add shortcut support for option+left option+right [API-1562]

### DIFF
--- a/internal/go-prompt/emacs.go
+++ b/internal/go-prompt/emacs.go
@@ -96,11 +96,25 @@ var emacsKeyBindings = []KeyBind{
 			buf.CursorRight(1)
 		},
 	},
+	// Alt Right allow: Forward one word
+	{
+		Key: AltRight,
+		Fn: func(buf *Buffer) {
+			buf.CursorRight(buf.Document().FindEndOfCurrentWordWithSpace())
+		},
+	},
 	// Left allow: Backward one character
 	{
 		Key: ControlB,
 		Fn: func(buf *Buffer) {
 			buf.CursorLeft(1)
+		},
+	},
+	// Alt Left allow: Backward one word
+	{
+		Key: AltLeft,
+		Fn: func(buf *Buffer) {
+			buf.CursorLeft(len([]rune(buf.Document().TextBeforeCursor())) - buf.Document().FindStartOfPreviousWordWithSpace())
 		},
 	},
 	// Cut the Word before the cursor.

--- a/internal/go-prompt/input.go
+++ b/internal/go-prompt/input.go
@@ -71,7 +71,9 @@ var ASCIISequences = []*ASCIICode{
 	{Key: Up, ASCIICode: []byte{0x1b, 0x5b, 0x41}},
 	{Key: Down, ASCIICode: []byte{0x1b, 0x5b, 0x42}},
 	{Key: Right, ASCIICode: []byte{0x1b, 0x5b, 0x43}},
+	{Key: AltRight, ASCIICode: []byte{0x1b, 0x1b, 0x5b, 0x43}},
 	{Key: Left, ASCIICode: []byte{0x1b, 0x5b, 0x44}},
+	{Key: AltLeft, ASCIICode: []byte{0x1b, 0x1b, 0x5b, 0x44}},
 	{Key: Home, ASCIICode: []byte{0x1b, 0x5b, 0x48}},
 	{Key: Home, ASCIICode: []byte{0x1b, 0x30, 0x48}},
 	{Key: End, ASCIICode: []byte{0x1b, 0x5b, 0x46}},
@@ -166,4 +168,8 @@ var ASCIISequences = []*ASCIICode{
 
 	{Key: Ignore, ASCIICode: []byte{0x1b, 0x5b, 0x45}}, // Xterm
 	{Key: Ignore, ASCIICode: []byte{0x1b, 0x5b, 0x46}}, // Linux console
+
+	// MacOS Keybind
+	{Key: AltRight, ASCIICode: []byte{0x1b, 0x66}},
+	{Key: AltLeft, ASCIICode: []byte{0x1b, 0x62}},
 }

--- a/internal/go-prompt/key.go
+++ b/internal/go-prompt/key.go
@@ -56,7 +56,9 @@ const (
 	Up
 	Down
 	Right
+	AltRight
 	Left
+	AltLeft
 
 	ShiftLeft
 	ShiftUp


### PR DESCRIPTION
Add shortcut support for option+left option+right which are available on macOS

I got these changes from https://github.com/c-bata/go-prompt/pull/261