### PR TITLE
Fix Flag Validation for Interactive Mode [API-1563]

### DIFF
--- a/clustercmd/cluster.go
+++ b/clustercmd/cluster.go
@@ -65,7 +65,7 @@ func New(config *hazelcast.Config) *cobra.Command {
 			Use:   sc.command,
 			Short: sc.info,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				defer hzcerrors.ErrorRecover()
+				defer hzcerrors.ErrorRecover(cmd.ErrOrStderr())
 				result, err := internal.CallClusterOperation(config, sc.command)
 				if err != nil {
 					return err
@@ -89,7 +89,7 @@ func NewChangeState(config *hazelcast.Config) *cobra.Command {
 		Use:   fmt.Sprintf("change-state [--state [%s]]", strings.Join(states, ",")),
 		Short: "Change state of the cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			defer hzcerrors.ErrorRecover()
+			defer hzcerrors.ErrorRecover(cmd.ErrOrStderr())
 			result, err := internal.CallClusterOperationWithState(config, "change-state", &newState)
 			if err != nil {
 				return err

--- a/clustercmd/cluster.go
+++ b/clustercmd/cluster.go
@@ -40,6 +40,8 @@ func New(config *hazelcast.Config) *cobra.Command {
 			}
 			return nil
 		},
+		DisableFlagParsing: true,
+		RunE:               hzcerrors.RootRunnerFnc,
 	}
 	subCmds := []struct {
 		command string
@@ -62,8 +64,9 @@ func New(config *hazelcast.Config) *cobra.Command {
 		// copy to use it in the inner func
 		sc := sc
 		cmd.AddCommand(&cobra.Command{
-			Use:   sc.command,
-			Short: sc.info,
+			Use:     sc.command,
+			Short:   sc.info,
+			PreRunE: hzcerrors.RequiredFlagChecker,
 			RunE: func(cmd *cobra.Command, args []string) error {
 				defer hzcerrors.ErrorRecover(cmd.ErrOrStderr())
 				result, err := internal.CallClusterOperation(config, sc.command)
@@ -86,8 +89,9 @@ func NewChangeState(config *hazelcast.Config) *cobra.Command {
 	// monitored flag variable
 	var newState string
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("change-state [--state [%s]]", strings.Join(states, ",")),
-		Short: "Change state of the cluster",
+		Use:     fmt.Sprintf("change-state [--state [%s]]", strings.Join(states, ",")),
+		Short:   "Change state of the cluster",
+		PreRunE: hzcerrors.RequiredFlagChecker,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			defer hzcerrors.ErrorRecover(cmd.ErrOrStderr())
 			result, err := internal.CallClusterOperationWithState(config, "change-state", &newState)

--- a/errors/error.go
+++ b/errors/error.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"strings"
@@ -44,10 +45,10 @@ For operations that change state/configuration of the cluster (e.g. "cluster cha
 To change CLUSTER_WRITE permission, see the documentation: https://docs.hazelcast.com/hazelcast/latest/maintain-cluster/rest-api#using-rest-endpoint-groups`
 )
 
-func ErrorRecover() {
+func ErrorRecover(out io.Writer) {
 	obj := recover()
 	if err, ok := obj.(error); ok {
-		fmt.Println(err)
+		_, _ = fmt.Fprintln(out, err)
 	}
 }
 

--- a/internal/cobraprompt/prompt.go
+++ b/internal/cobraprompt/prompt.go
@@ -188,8 +188,8 @@ func (co CobraPrompt) Run(ctx context.Context, root *cobra.Command, cnfg *hazelc
 				return
 			}
 			// re-init command chain every iteration
-			// ignore global flags, they are already parsed
-			root, _ = rootcmd.New(cnfg)
+			// skip the persistent flags since they are parsed on the initial command
+			root = rootcmd.NewWithoutPersistentFlags(cnfg)
 			prepareRootCmdForPrompt(co, root)
 			root.SetArgs(promptArgs)
 			root.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {

--- a/internal/cobraprompt/prompt.go
+++ b/internal/cobraprompt/prompt.go
@@ -90,10 +90,12 @@ func handleExit() {
 		if errors.Is(v, ErrExit) {
 			return
 		}
-		fmt.Println(v)
+		// skip err nothing to do
+		_, _ = fmt.Fprintln(os.Stderr, v)
 	default:
-		fmt.Println(v)
-		fmt.Println(string(debug.Stack()))
+		// skip err nothing to do
+		_, _ = fmt.Fprintln(os.Stderr, v)
+		_, _ = fmt.Fprintln(os.Stderr, string(debug.Stack()))
 	}
 }
 
@@ -182,7 +184,7 @@ func (co CobraPrompt) Run(ctx context.Context, root *cobra.Command, cnfg *hazelc
 			}
 			promptArgs, err := shlex.Split(in)
 			if err != nil {
-				fmt.Println("unable to parse commands")
+				root.PrintErrln("unable to parse commands")
 				return
 			}
 			// re-init command chain every iteration

--- a/internal/cobraprompt/prompt.go
+++ b/internal/cobraprompt/prompt.go
@@ -83,7 +83,7 @@ func exitPromptSafely() {
 	panic(ErrExit)
 }
 
-func handleExit(l *log.Logger) {
+func handleExit() {
 	switch v := recover().(type) {
 	case nil:
 		return
@@ -241,13 +241,10 @@ func (co CobraPrompt) Init(ctx context.Context, root *cobra.Command, cnfg *hazel
 }
 
 func initInteractiveRootCmd(cnfg *hazelcast.Config, root *cobra.Command, co CobraPrompt, args []string) *cobra.Command {
-	// ignore global flags, they are already parsed
-	rootCopy, _ := rootcmd.New(cnfg, true)
+	// skip the persistent flags since they are parsed on the initial command
+	rootCopy := rootcmd.NewWithoutPersistentFlags(cnfg, true)
 	prepareRootCmdForPrompt(co, rootCopy)
 	cobra_util.InitCommandForCustomInvocation(rootCopy, root.InOrStdin(), root.OutOrStdout(), root.OutOrStderr(), args)
-	rootCopy.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
-		return hzcerrors.FlagError(err)
-	})
 	return rootCopy
 }
 
@@ -257,7 +254,7 @@ type GoPromptWithGracefulShutdown struct {
 }
 
 func (gp *GoPromptWithGracefulShutdown) Run() {
-	defer handleExit(gp.l)
+	defer handleExit()
 	gp.p.Run()
 }
 

--- a/internal/cobraprompt/prompt.go
+++ b/internal/cobraprompt/prompt.go
@@ -30,7 +30,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	hzcerrors "github.com/hazelcast/hazelcast-commandline-client/errors"
 	"github.com/hazelcast/hazelcast-commandline-client/internal"
 	goprompt "github.com/hazelcast/hazelcast-commandline-client/internal/go-prompt"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/tuiutil"
@@ -192,9 +191,6 @@ func (co CobraPrompt) Run(ctx context.Context, root *cobra.Command, cnfg *hazelc
 			root = rootcmd.NewWithoutPersistentFlags(cnfg)
 			prepareRootCmdForPrompt(co, root)
 			root.SetArgs(promptArgs)
-			root.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
-				return hzcerrors.FlagError(err)
-			})
 			os.Args = promptArgs
 			err = root.ExecuteContext(ctx)
 			if _, writeErr := f.WriteString(fmt.Sprintln(in)); writeErr != nil {

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 
@@ -56,6 +57,7 @@ func ExitOnError(err error, logger *log.Logger) {
 		return
 	}
 	errStr := HandleError(err)
-	logger.Println(errStr)
+	// ignore err, nothing to do
+	_, _ = fmt.Fprintln(os.Stderr, errStr)
 	os.Exit(exitError)
 }

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/hazelcast/hazelcast-commandline-client/runner"

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/hazelcast/hazelcast-commandline-client/config"
@@ -36,7 +35,7 @@ func main() {
 	programArgs := os.Args[1:]
 	// update config before running root command to make sure flags are processed
 	err := updateConfigWithFlags(rootCmd, &cfg, programArgs, globalFlagValues)
-	ExitOnError(err, cfg.Logger)
+	ExitOnError(err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	isInteractive := IsInteractiveCall(rootCmd, programArgs)
@@ -47,12 +46,12 @@ func main() {
 		// there is no need for second parameter anymore. The purpose is overwriting rootCmd as it is at the beginning.
 		rootCmd, _ = rootcmd.New(&cfg.Hazelcast)
 		err = RunCmd(ctx, rootCmd)
-		ExitOnError(err, cfg.Logger)
+		ExitOnError(err)
 	}
 	return
 }
 
-func ExitOnError(err error, logger *log.Logger) {
+func ExitOnError(err error) {
 	if err == nil {
 		return
 	}

--- a/rootcmd/root.go
+++ b/rootcmd/root.go
@@ -34,7 +34,14 @@ import (
 
 // New initializes root command for non-interactive mode
 func New(cnfg *hazelcast.Config) (*cobra.Command, *config.GlobalFlagValues) {
+	root := NewWithoutPersistentFlags(cnfg)
 	var flags config.GlobalFlagValues
+	assignPersistentFlags(root, &flags)
+	return root, &flags
+}
+
+// NewWithoutPersistentFlags initializes root command without the persistent flags
+func NewWithoutPersistentFlags(cnfg *hazelcast.Config) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "hzc {cluster | map | sql | version | help} [--address address | --cloud-token token | --cluster-name name | --config config]",
 		Short: "Hazelcast command-line client",
@@ -61,9 +68,8 @@ hzc help # print help`,
 	if mode := os.Getenv("MODE"); strings.EqualFold(mode, "dev") {
 		root.CompletionOptions.DisableDefaultCmd = false
 	}
-	assignPersistentFlags(root, &flags)
 	root.AddCommand(subCommands(cnfg)...)
-	return root, &flags
+	return root
 }
 
 func subCommands(config *hazelcast.Config) []*cobra.Command {

--- a/rootcmd/root.go
+++ b/rootcmd/root.go
@@ -36,14 +36,14 @@ import (
 
 // New initializes root command for non-interactive mode
 func New(cnfg *hazelcast.Config, isInteractiveInvocation bool) (*cobra.Command, *config.GlobalFlagValues) {
-	root := NewWithoutPersistentFlags(cnfg)
+	root := NewWithoutPersistentFlags(cnfg, isInteractiveInvocation)
 	var flags config.GlobalFlagValues
 	assignPersistentFlags(root, &flags)
 	return root, &flags
 }
 
 // NewWithoutPersistentFlags initializes root command without the persistent flags
-func NewWithoutPersistentFlags(cnfg *hazelcast.Config) *cobra.Command {
+func NewWithoutPersistentFlags(cnfg *hazelcast.Config, isInteractiveInvocation bool) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "hzc {cluster | map | sql | version | help} [--address address | --cloud-token token | --cluster-name name | --config config]",
 		Short: "Hazelcast command-line client",

--- a/rootcmd/root.go
+++ b/rootcmd/root.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-commandline-client/clustercmd"
 	"github.com/hazelcast/hazelcast-commandline-client/config"
+	hzcerrors "github.com/hazelcast/hazelcast-commandline-client/errors"
 	"github.com/hazelcast/hazelcast-commandline-client/sqlcmd"
 	fakeDoor "github.com/hazelcast/hazelcast-commandline-client/types/fakedoorcmd"
 	"github.com/hazelcast/hazelcast-commandline-client/types/mapcmd"
@@ -52,6 +53,7 @@ hzc sql # starts the SQL Browser
 hzc help # print help`,
 		// Handle errors explicitly
 		SilenceErrors: true,
+		SilenceUsage:  true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Make sure the command receives non-nil configuration
 			if cnfg == nil {
@@ -63,6 +65,11 @@ hzc help # print help`,
 			return cmd.Help()
 		},
 	}
+	// print usage on flag errors
+	root.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		_ = cmd.Help()
+		return hzcerrors.FlagError{err}
+	})
 	root.CompletionOptions.DisableDefaultCmd = true
 	// This is used to generate completion scripts
 	if mode := os.Getenv("MODE"); strings.EqualFold(mode, "dev") {

--- a/run.go
+++ b/run.go
@@ -90,14 +90,14 @@ func RunCmdInteractively(ctx context.Context, rootCmd *cobra.Command, cnfg *conf
 		},
 		OnErrorFunc: func(err error) {
 			errStr := HandleError(err)
-			cnfg.Logger.Println(errStr)
+			rootCmd.PrintErrln(errStr)
 			return
 		},
 		Persister: namePersister,
 	}
 	rootCmd.Println("Connecting to the cluster ...")
 	if _, err := internal.ConnectToCluster(ctx, hConfig); err != nil {
-		rootCmd.Printf("Error: %s\n", err)
+		rootCmd.PrintErrf("Error: %s\n", err)
 		return
 	}
 	var flagsToExclude []string
@@ -118,10 +118,11 @@ func updateConfigWithFlags(rootCmd *cobra.Command, cnfg *config.Config, programA
 	// parse global persistent flags
 	subCmd, flags, _ := rootCmd.Find(programArgs)
 	// fall back to cmd.Help, even if there is error
-	_ = subCmd.ParseFlags(flags)
+	if err := subCmd.ParseFlags(flags); err != nil {
+		return err
+	}
 	// initialize config from file
-	err := config.ReadAndMergeWithFlags(globalFlagValues, cnfg)
-	return err
+	return config.ReadAndMergeWithFlags(globalFlagValues, cnfg)
 }
 
 func HandleError(err error) string {

--- a/runner/run.go
+++ b/runner/run.go
@@ -140,14 +140,13 @@ func ProcessConfigAndFlags(rootCmd *cobra.Command, cnfg *config.Config, programA
 	// parse global persistent flags
 	subCmd, flags, err := rootCmd.Find(programArgs)
 	if err != nil {
-		return err
+		return defaultLogger, err
 	}
 	// fall back to cmd.Help, even if there is error
 	if err := subCmd.ParseFlags(flags); err != nil {
 		_ = subCmd.Help()
-		return err
+		return defaultLogger, err
 	}
-	var err error
 	// initialize config from file
 	if err = config.ReadAndMergeWithFlags(globalFlagValues, cnfg); err != nil {
 		return defaultLogger, err

--- a/types/mapcmd/clear.go
+++ b/types/mapcmd/clear.go
@@ -32,6 +32,7 @@ func NewClear(config *hazelcast.Config) *cobra.Command {
 		Use:     "clear [--name mapname]",
 		Short:   "Clear entries of the map",
 		Example: MapClearExample,
+		PreRunE: hzcerrors.RequiredFlagChecker,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			m, err := getMap(cmd.Context(), config, mapName)

--- a/types/mapcmd/get-all.go
+++ b/types/mapcmd/get-all.go
@@ -47,6 +47,7 @@ func NewGetAll(config *hazelcast.Config) *cobra.Command {
 		Use:     "get-all [--name mapname | [--key keyname]... [--delim delimiter]]",
 		Short:   "Get all matched entries from the map",
 		Example: MapGetAllExample,
+		PreRunE: hzcerrors.RequiredFlagChecker,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			if err = validateFlags(); err != nil {

--- a/types/mapcmd/get.go
+++ b/types/mapcmd/get.go
@@ -33,6 +33,7 @@ func NewGet(config *hazelcast.Config) *cobra.Command {
 		Use:     "get [--name mapname | --key keyname]",
 		Short:   "Get single entry from the map",
 		Example: MapGetExample,
+		PreRunE: hzcerrors.RequiredFlagChecker,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key, err := internal.ConvertString(mapKey, mapKeyType)
 			if err != nil {

--- a/types/mapcmd/map.go
+++ b/types/mapcmd/map.go
@@ -51,9 +51,10 @@ const (
 
 func New(config *hazelcast.Config) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "map {get | put | clear | put-all | get-all | remove} --name mapname --key keyname [--value-type type | --value-file file | --value value]",
-		Short:   "Map operations",
-		Example: fmt.Sprintf("%s\n%s\n%s", MapPutExample, MapGetExample, MapUseExample),
+		Use:                "map {get | put | clear | put-all | get-all | remove} --name mapname --key keyname [--value-type type | --value-file file | --value value]",
+		Short:              "Map operations",
+		DisableFlagParsing: true,
+		Example:            fmt.Sprintf("%s\n%s\n%s", MapPutExample, MapGetExample, MapUseExample),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// All the following lines are to set map name if it is set by "use" command.
 			// If the map name is given explicitly, do not set the one given with "use" command.
@@ -78,6 +79,7 @@ func New(config *hazelcast.Config) *cobra.Command {
 			}
 			return nil
 		},
+		RunE: hzcerrors.RootRunnerFnc,
 	}
 	cmd.AddCommand(
 		NewPut(config),

--- a/types/mapcmd/put-all.go
+++ b/types/mapcmd/put-all.go
@@ -93,6 +93,7 @@ func NewPutAll(config *hazelcast.Config) *cobra.Command {
 		Short:      "Put values to map",
 		Long:       "",
 		Example:    MapPutAllExample,
+		PreRunE:    hzcerrors.RequiredFlagChecker,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			if jsonEntryPath != "" {

--- a/types/mapcmd/put.go
+++ b/types/mapcmd/put.go
@@ -46,6 +46,7 @@ func NewPut(config *hazelcast.Config) *cobra.Command {
 		Use:     "put [--name mapname | --key keyname | --value-type type | {--value-file file | --value value} | --ttl ttl | --max-idle max-idle]",
 		Short:   "Put value to map",
 		Example: MapPutExample,
+		PreRunE: hzcerrors.RequiredFlagChecker,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key, err := internal.ConvertString(mapKey, mapKeyType)
 			if err != nil {

--- a/types/mapcmd/remove.go
+++ b/types/mapcmd/remove.go
@@ -35,6 +35,7 @@ func NewRemove(config *hazelcast.Config) *cobra.Command {
 		Short: "Remove key",
 		Example: `  # Remove key from the map
   hzc map remove -n mapname -k k1`,
+		PreRunE: hzcerrors.RequiredFlagChecker,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key, err := internal.ConvertString(mapKey, mapKeyType)
 			if err != nil {

--- a/types/mapcmd/use.go
+++ b/types/mapcmd/use.go
@@ -19,6 +19,7 @@ package mapcmd
 import (
 	"github.com/spf13/cobra"
 
+	hzcerrors "github.com/hazelcast/hazelcast-commandline-client/errors"
 	"github.com/hazelcast/hazelcast-commandline-client/internal"
 )
 
@@ -31,6 +32,7 @@ func NewUse() *cobra.Command {
 		Use:     `use [map-name | --reset]`,
 		Short:   "sets the default map name (interactive-mode only)",
 		Example: MapUseExample,
+		PreRunE: hzcerrors.RequiredFlagChecker,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			persister := internal.PersistedNamesFromContext(cmd.Context())
 			if cmd.Flags().Changed("reset") {


### PR DESCRIPTION
Fix flag validation for interactive mode (turns out it works ok for non-interactive)

Also apart from that, CLC-related errors were being logged instead of "being printed to stderr". This PR fixes that.