### PR TITLE
Update paths for Windows[API-1542]

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -300,7 +300,8 @@ func DefaultConfigPath() (string, error) {
 		if dir == "" {
 			return "", errors.New("%AppData% is not defined")
 		}
-		return filepath.Join(dir, "Roaming", "Hazelcast CLC"), nil
+		// C:\Users\USERNAME\AppData\Roaming
+		return filepath.Join(dir, "Hazelcast CLC"), nil
 	}
 	path, err := file.HZCHomePath()
 	return filepath.Join(path, defaultConfigFilename), err

--- a/connwizardcmd/connection.go
+++ b/connwizardcmd/connection.go
@@ -2,10 +2,12 @@ package connwizardcmd
 
 import (
 	"errors"
+
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+
 	"github.com/hazelcast/hazelcast-commandline-client/config"
 	hzcerrors "github.com/hazelcast/hazelcast-commandline-client/errors"
-	"github.com/spf13/cobra"
 )
 
 func New() *cobra.Command {
@@ -63,7 +65,11 @@ func handleExit(cmd *cobra.Command) error {
 func handleWrite(cmd *cobra.Command, c *config.Config, choice string) error {
 	if choice == "y" {
 		exists := config.ConfigExists()
-		err := config.WriteToFile(c, config.DefaultConfigPath())
+		p, err := config.DefaultConfigPath()
+		if err != nil {
+			return hzcerrors.NewLoggableError(err, "Can not locate config path %s", p)
+		}
+		err = config.WriteToFile(c, p)
 		if err != nil {
 			return hzcerrors.NewLoggableError(err, "There was an error during overwriting config file.")
 		} else if exists {

--- a/internal/cobraprompt/prompt.go
+++ b/internal/cobraprompt/prompt.go
@@ -153,12 +153,16 @@ func (co CobraPrompt) Init(ctx context.Context, root *cobra.Command, cnfg *hazel
 	co.GoPromptOptions = append(co.GoPromptOptions, Themes[tuiutil.SelectedTheme]...)
 	co.GoPromptOptions = append(co.GoPromptOptions, OptionsHookForTests...)
 	history := goprompt.NewHistory()
-	f, err := os.OpenFile(cmdHistoryPath, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0600)
+	var f *os.File
+	var err error
+	if cmdHistoryPath != "" {
+		f, err = os.OpenFile(cmdHistoryPath, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0600)
+	}
 	defer func() {
 		f.Close()
 	}()
-	if err != nil {
-		logger.Printf("Can not open command history file. There will be no history information: %s\n", err.Error())
+	if f == nil {
+		logger.Printf("Can not open command history file. There will be no history information\n")
 	} else {
 		scanner := bufio.NewScanner(f)
 		for scanner.Scan() {

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -24,10 +24,11 @@ func Exists(path string) (bool, error) {
 
 func HZCHomePath() (string, error) {
 	if runtime.GOOS == "windows" {
-		dir := os.Getenv("AppData")
+		dir := os.Getenv("LocalAppData")
 		if dir == "" {
-			return "", errors.New("%AppData% is not defined")
+			return "", errors.New("%LocalAppData% is not defined")
 		}
+		// C:\Users\USERNAME\AppData\Local
 		return filepath.Join(dir, "Local", "Hazelcast CLC"), nil
 	}
 	homeDirectoryPath, err := os.UserHomeDir()

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 func Exists(path string) (bool, error) {
@@ -21,12 +22,19 @@ func Exists(path string) (bool, error) {
 	return false, err
 }
 
-func HZCHomePath() string {
+func HZCHomePath() (string, error) {
+	if runtime.GOOS == "windows" {
+		dir := os.Getenv("AppData")
+		if dir == "" {
+			return "", errors.New("%AppData% is not defined")
+		}
+		return filepath.Join(dir, "Local", "Hazelcast CLC"), nil
+	}
 	homeDirectoryPath, err := os.UserHomeDir()
 	if err != nil {
 		panic(fmt.Errorf("retrieving home directory: %w", err))
 	}
-	return filepath.Join(homeDirectoryPath, ".local/share/hz-cli")
+	return filepath.Join(homeDirectoryPath, ".local/share/hz-cli"), nil
 }
 
 func CreateMissingDirsAndFileWithRWPerms(path string, content []byte) error {

--- a/rootcmd/root.go
+++ b/rootcmd/root.go
@@ -18,9 +18,10 @@ package rootcmd
 import (
 	"errors"
 	"fmt"
-	"github.com/hazelcast/hazelcast-commandline-client/connwizardcmd"
 	"os"
 	"strings"
+
+	"github.com/hazelcast/hazelcast-commandline-client/connwizardcmd"
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/spf13/cobra"
@@ -106,7 +107,8 @@ func subCommands(config *hazelcast.Config, isInteractiveInvocation bool) []*cobr
 
 // assignPersistentFlags assigns top level flags to command
 func assignPersistentFlags(cmd *cobra.Command, flags *config.GlobalFlagValues) {
-	cmd.PersistentFlags().StringVarP(&flags.CfgFile, "config", "c", config.DefaultConfigPath(), fmt.Sprintf("config file, only supports yaml for now"))
+	path, _ := config.DefaultConfigPath()
+	cmd.PersistentFlags().StringVarP(&flags.CfgFile, "config", "c", path, fmt.Sprintf("config file, only supports yaml for now"))
 	cmd.PersistentFlags().StringVarP(&flags.Address, "address", "a", "", fmt.Sprintf("addresses of the instances in the cluster (default is %s)", config.DefaultClusterAddress))
 	cmd.PersistentFlags().StringVar(&flags.Cluster, "cluster-name", "", fmt.Sprintf("name of the cluster that contains the instances (default is %s)", config.DefaultClusterName))
 	cmd.PersistentFlags().StringVar(&flags.Token, "cloud-token", "", "your Hazelcast Viridian token")


### PR DESCRIPTION
It has been discussed to follow the convention below for Windows paths:
Executable: `AppData/Local/Programs/Hazelcast CLC`
Config and "roamable" files: `AppData/Roaming/Hazelcast CLC`
Local data such as logs and command history: `AppData/Local/Hazelcast CLC`