### PR TITLE
Fix spinner text "Index out of range" error

### DIFF
--- a/internal/connection/singleton.go
+++ b/internal/connection/singleton.go
@@ -55,7 +55,6 @@ func ConnectToClusterInteractive(ctx context.Context, clientConfig *hazelcast.Co
 		escaped := false
 		m := newConnectionSpinnerModel(
 			clientConfig.Cluster.Name,
-			clientConfig.Cluster.Network.Addresses[0],
 			"logfile",
 			&escaped,
 		)

--- a/internal/connection/spinner.go
+++ b/internal/connection/spinner.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-const spinnerText = `Connecting to the cluster %s at %s.
+const spinnerText = `Trying to connect cluster %s.
    Check the logs at %s.`
 
 var (
@@ -20,20 +20,18 @@ var (
 
 type connectionSpinnerModel struct {
 	clusterName string
-	address     string
 	logFileName string
 	spinner     spinner.Model
 	escaped     *bool
 }
 
-func newConnectionSpinnerModel(clusterName, address, logfile string, escaped *bool) *connectionSpinnerModel {
+func newConnectionSpinnerModel(clusterName, logfile string, escaped *bool) *connectionSpinnerModel {
 	s := spinner.New()
 	s.Style = spinnerStyle
 	s.Spinner = currSpinner
 	return &connectionSpinnerModel{
 		spinner:     s,
 		clusterName: clusterName,
-		address:     address,
 		logFileName: logfile,
 		escaped:     escaped,
 	}
@@ -66,7 +64,7 @@ func (m connectionSpinnerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m connectionSpinnerModel) View() (s string) {
-	info := fmt.Sprintf(spinnerText, m.clusterName, m.address, m.logFileName)
+	info := fmt.Sprintf(spinnerText, m.clusterName, m.logFileName)
 	s = fmt.Sprintf("\n%s %s\n", m.spinner.View(), info)
 	s += helpStyle("\nCTRL+C to exit.\n")
 	return


### PR DESCRIPTION
When the addresses section is empty in the config file (default behavior when connecting to Viridian), the spinner throws out of range error since it is trying to get the first address in the config. Also, it is not correct since there might be more than one member, and we could connect another member differently than we display in the spinner. 