### PR TITLE
Prevent localhost address on config when Viridian is enabled.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -99,11 +99,13 @@ const defaultUserConfig = `hazelcast:
       # 0s is no timeout
       connectiontimeout: {{ .Hazelcast.Cluster.Network.ConnectionTimeout}}
       addresses:
-      {{- range .Hazelcast.Cluster.Network.Addresses}}
+      {{ if not .Hazelcast.Cluster.Cloud.Enabled -}}
+      {{- range .Hazelcast.Cluster.Network.Addresses }}
         - {{ . -}}
-      {{ else }}
+      {{ else -}}
         - localhost:5701
-      {{- end }}
+      {{- end -}}
+	  {{ end }}
     cloud:
       token: "{{ .Hazelcast.Cluster.Cloud.Token}}"
       enabled: {{ .Hazelcast.Cluster.Cloud.Enabled}}


### PR DESCRIPTION
Currently, config template writes `localhost:5701` when there is no address specified, but it is inconvenient since user might be connecting to Viridian. This PR fixes and leave addresses empty when cloud is enabled.