### PR TITLE
[EASY] Fix CLC commands in the shell

### DIFF
--- a/clc/cmd/clc.go
+++ b/clc/cmd/clc.go
@@ -276,6 +276,10 @@ func (m *Main) createCommands() error {
 				return fmt.Errorf("initializing command: %w", err)
 			}
 		}
+		// add the backslash prefix for top-level commands in the interactive mode
+		if m.isInteractive && parent == m.root {
+			cmd.Use = fmt.Sprintf("\\%s", cmd.Use)
+		}
 		parent.AddGroup(cc.Groups()...)
 		if !cc.TopLevel() {
 			cmd.RunE = func(cmd *cobra.Command, args []string) error {

--- a/clc/cmd/command_context.go
+++ b/clc/cmd/command_context.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -90,11 +88,7 @@ func (cc *CommandContext) SetCommandHelp(long, short string) {
 }
 
 func (cc *CommandContext) SetCommandUsage(usage string) {
-	pfx := ""
-	if cc.isInteractive {
-		pfx = "\\"
-	}
-	cc.Cmd.Use = fmt.Sprintf("%s%s", pfx, usage)
+	cc.Cmd.Use = usage
 }
 
 func (cc *CommandContext) SetCommandGroup(id string) {


### PR DESCRIPTION
This PR fixes prefixing backslash to commands in the shell by prefixing them only if they are a top level command.