### PR TITLE
DOCS-380 Update version for Algolia search

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -2,15 +2,15 @@ name: clc
 title: Hazelcast CLC
 start_page: overview.adoc
 # Version in the URL
-version: '5.2.0-BETA-3'
+version: '5.2.0-beta-3'
 # Version in the version selector (we display only the latest major.minor version)
-display_version: '5.2.0-Beta-3'
+display_version: '5.2.0-BETA-3'
 # Displays a banner to inform users that this is a prerelease version 
 prerelease: true
 asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
-    full-version: '5.2.0-Beta-3'
+    full-version: '5.2.0-BETA-3'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true
     snapshot: true

--- a/docs/modules/ROOT/pages/release-notes.adoc
+++ b/docs/modules/ROOT/pages/release-notes.adoc
@@ -1,4 +1,4 @@
-= Release Notes Hazelcast CLC {page-component-version}
+= Release Notes Hazelcast CLC {full-version}
 
 == New Features
 


### PR DESCRIPTION
- Docs version updated to match search tag for algolia search
- Displayed version numbers made consistent. Now all are upper-case