### PR TITLE
Map name parameter gets stuck to a value in the shell mode [API-1934]

### DIFF
--- a/base/commands/map/map.go
+++ b/base/commands/map/map.go
@@ -45,10 +45,10 @@ func (mc *MapCommand) Exec(context.Context, plug.ExecContext) error {
 func (mc *MapCommand) Augment(ec plug.ExecContext, props *plug.Properties) error {
 	ctx := context.TODO()
 	props.SetBlocking(mapPropertyName, func() (any, error) {
-		if mc.m != nil {
+		mapName := ec.Props().GetString(mapFlagName)
+		if mc.m != nil && mc.m.Name() == mapName {
 			return mc.m, nil
 		}
-		mapName := ec.Props().GetString(mapFlagName)
 		// empty map name is allowed
 		ci, err := ec.ClientInternal(ctx)
 		if err != nil {

--- a/base/commands/map/map.go
+++ b/base/commands/map/map.go
@@ -5,7 +5,6 @@ package _map
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/hazelcast/hazelcast-go-client"
 
@@ -22,8 +21,6 @@ const (
 )
 
 type MapCommand struct {
-	mu *sync.RWMutex
-	ms map[string]*hazelcast.Map
 }
 
 func (mc *MapCommand) Init(cc plug.InitContext) error {
@@ -36,8 +33,6 @@ func (mc *MapCommand) Init(cc plug.InitContext) error {
 	cc.SetTopLevel(true)
 	cc.SetCommandUsage("map COMMAND [flags]")
 	help := "Map operations"
-	mc.mu = &sync.RWMutex{}
-	mc.ms = map[string]*hazelcast.Map{}
 	cc.SetCommandHelp(help, help)
 	return nil
 }
@@ -50,12 +45,6 @@ func (mc *MapCommand) Augment(ec plug.ExecContext, props *plug.Properties) error
 	ctx := context.TODO()
 	props.SetBlocking(mapPropertyName, func() (any, error) {
 		mapName := ec.Props().GetString(mapFlagName)
-		mc.mu.RLock()
-		m, ok := mc.ms[mapName]
-		mc.mu.RUnlock()
-		if ok {
-			return m, nil
-		}
 		// empty map name is allowed
 		ci, err := ec.ClientInternal(ctx)
 		if err != nil {
@@ -73,9 +62,6 @@ func (mc *MapCommand) Augment(ec plug.ExecContext, props *plug.Properties) error
 			return nil, err
 		}
 		stop()
-		mc.mu.Lock()
-		mc.ms[mapName] = mv.(*hazelcast.Map)
-		mc.mu.Unlock()
 		return mv.(*hazelcast.Map), nil
 	})
 	return nil

--- a/base/commands/map/map_size.go
+++ b/base/commands/map/map_size.go
@@ -34,7 +34,6 @@ func (mc *MapSizeCommand) Exec(ctx context.Context, ec plug.ExecContext) error {
 	hint := fmt.Sprintf("Getting the size of the map %s", mapName)
 	sv, stop, err := ec.ExecuteBlocking(ctx, hint, func(ctx context.Context) (any, error) {
 		return m.Size(ctx)
-
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes: #186 

Blocking call of `map` was saving the created proxy object and returning it in the subsequent commands directly without creating a new proxy. This behaviour results in constant map proxy even if a different map name is specified. 

A new check is added to return if the saved proxy's name matches with the requested map name.