### PR TITLE
Add CLC label to client properties for MC.

### DIFF
--- a/clc/config/config.go
+++ b/clc/config/config.go
@@ -117,6 +117,7 @@ func MakeHzConfig(props plug.ReadOnlyProperties, lg *logger.Logger) (hazelcast.C
 			}
 		}
 	}
+	cfg.Labels = []string{"CLC"}
 	cfg.ClientName = makeClientName()
 	usr := props.GetString(clc.PropertyClusterUser)
 	pass := props.GetString(clc.PropertyClusterPassword)

--- a/clc/config/config_test.go
+++ b/clc/config/config_test.go
@@ -29,6 +29,7 @@ func TestMakeConfiguration_Default(t *testing.T) {
 	require.NoError(t, err)
 	var target hazelcast.Config
 	target.ClientName = "my-client"
+	target.Labels = []string{"CLC"}
 	target.Cluster.Unisocket = true
 	target.Stats.Enabled = true
 	target.Logger.CustomLogger = lg
@@ -55,6 +56,7 @@ func TestMakeConfiguration_Viridian(t *testing.T) {
 	require.NoError(t, err)
 	var target hazelcast.Config
 	target.ClientName = "my-client"
+	target.Labels = []string{"CLC"}
 	target.Cluster.Unisocket = true
 	target.Cluster.Name = "pr-3066"
 	target.Cluster.Cloud.Enabled = true


### PR DESCRIPTION
Labels are displayed in the MC client console for identifying clients.

This PR resolves the ticket but I can implement a `GetStringList()` method for `ReadOnlyProperties` to read labels from config files and assign it to Hazelcast client configuration. Wdyt @yuce, is this change enough?