### PR TITLE
Add cluster management commands [CLC-163]

### DIFF
--- a/base/commands/viridian/const.go
+++ b/base/commands/viridian/const.go
@@ -1,0 +1,8 @@
+package viridian
+
+const (
+	flagName        = "name"
+	flagPlan        = "plan"
+	flagDevelopment = "development"
+	flagOutputDir   = "output-dir"
+)

--- a/base/commands/viridian/custom_class_it_test.go
+++ b/base/commands/viridian/custom_class_it_test.go
@@ -16,37 +16,37 @@ func customClass_NonInteractiveTest(t *testing.T) {
 		// setup
 		f := "foo.zip"
 		fd := "testdata/" + f
-		cid := ensureClusterRunning(ctx, tcx)
+		c := createOrGetClusterWithState(ctx, tcx, "RUNNING")
 		// test upload custom class
 		tcx.WithReset(func() {
-			tcx.CLCExecute(ctx, "viridian", "upload-custom-class", cid, fd)
+			tcx.CLCExecute(ctx, "viridian", "upload-custom-class", c.ID, fd)
 			tcx.AssertStderrContains("OK")
 			check.Must(waitCustomClassOperation(ctx, tcx, "Custom class uploaded successfully."))
 		})
 		id := ""
 		// test list custom class
 		tcx.WithReset(func() {
-			tcx.CLCExecute(ctx, "viridian", "list-custom-classes", cid)
+			tcx.CLCExecute(ctx, "viridian", "list-custom-classes", c.ID)
 			tcx.AssertStderrContains("OK")
 			id = customClassID(tcx.ExpectStdout.String())
 			tcx.AssertStdoutContains(f)
 		})
 		// test download custom class
 		tcx.WithReset(func() {
-			tcx.CLCExecute(ctx, "viridian", "download-custom-class", cid, f)
+			tcx.CLCExecute(ctx, "viridian", "download-custom-class", c.ID, f)
 			tcx.AssertStderrContains("OK")
 			tcx.AssertStdoutContains("Custom class downloaded successfully.")
 		})
 		// test delete custom class
 		tcx.WithReset(func() {
-			check.Must(waitState(ctx, tcx, cid, "RUNNING"))
-			tcx.CLCExecute(ctx, "viridian", "delete-custom-class", cid, id)
+			check.Must(waitState(ctx, tcx, c.ID, "RUNNING"))
+			tcx.CLCExecute(ctx, "viridian", "delete-custom-class", c.ID, id)
 			check.Must(waitCustomClassOperation(ctx, tcx, "Custom class deleted successfully."))
 			tcx.AssertStderrContains("OK")
 		})
 		// check the list output again to be sure that delete was really successful
 		tcx.WithReset(func() {
-			tcx.CLCExecute(ctx, "viridian", "list-custom-classes", cid)
+			tcx.CLCExecute(ctx, "viridian", "list-custom-classes", c.ID)
 			tcx.AssertStderrContains("OK")
 			tcx.AssertStderrNotContains(f)
 		})

--- a/base/commands/viridian/download_logs.go
+++ b/base/commands/viridian/download_logs.go
@@ -19,7 +19,7 @@ func (cm DownloadLogsCmd) Init(cc plug.InitContext) error {
 
 Make sure you login before running this command.
 `
-	short := "Gets Viridian cluster"
+	short := "Downloads the logs of the given Viridian cluster"
 	cc.SetCommandHelp(long, short)
 	cc.SetPositionalArgCount(1, 1)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")

--- a/base/commands/viridian/download_logs.go
+++ b/base/commands/viridian/download_logs.go
@@ -1,0 +1,74 @@
+package viridian
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
+)
+
+type DownloadLogsCmd struct{}
+
+func (cm DownloadLogsCmd) Init(cc plug.InitContext) error {
+	cc.SetCommandUsage("download-logs [cluster-ID/name] [flags]")
+	long := `Downloads the logs of the given Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+`
+	short := "Gets Viridian cluster"
+	cc.SetCommandHelp(long, short)
+	cc.SetPositionalArgCount(1, 1)
+	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
+	cc.AddStringFlag(flagOutputDir, "o", "", false, "output directory for the log files, if not given current directory is used")
+	return nil
+}
+
+func (cm DownloadLogsCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
+	api, err := getAPI(ec)
+	if err != nil {
+		return err
+	}
+	clusterNameOrID := ec.Args()[0]
+	outDir := ec.Props().GetString(flagOutputDir)
+	// extract target info
+	err = validateOutputDir(outDir)
+	if err != nil {
+		return err
+	}
+	_, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
+		sp.SetText("Downloading cluster logs")
+		err := api.DownloadClusterLogs(ctx, outDir, clusterNameOrID)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+	if err != nil {
+		ec.Logger().Error(err)
+		return fmt.Errorf("error downloading cluster logs. Did you login?: %w", err)
+	}
+	stop()
+	return nil
+}
+
+func init() {
+	Must(plug.Registry.RegisterCommand("viridian:download-logs", &DownloadLogsCmd{}))
+}
+
+func validateOutputDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.IsDir() {
+		return nil
+	}
+	return errors.New("output-dir is not a directory")
+}

--- a/base/commands/viridian/download_logs.go
+++ b/base/commands/viridian/download_logs.go
@@ -35,8 +35,7 @@ func (cm DownloadLogsCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	clusterNameOrID := ec.Args()[0]
 	outDir := ec.Props().GetString(flagOutputDir)
 	// extract target info
-	err = validateOutputDir(outDir)
-	if err != nil {
+	if err := validateOutputDir(outDir); err != nil {
 		return err
 	}
 	_, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {

--- a/base/commands/viridian/download_logs_it_test.go
+++ b/base/commands/viridian/download_logs_it_test.go
@@ -1,0 +1,46 @@
+package viridian_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/it"
+)
+
+func downloadLogs_NonInteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		dir := check.MustValue(os.MkdirTemp("", "log"))
+		defer func() { check.Must(os.RemoveAll(dir)) }()
+		c := createOrGetClusterWithState(ctx, tcx, "RUNNING")
+		tcx.WithReset(func() {
+			tcx.CLCExecute(ctx, "viridian", "download-logs", c.ID, "--output-dir", dir)
+			tcx.AssertStderrContains("OK")
+			require.FileExists(t, path.Join(dir, "node-1.log"))
+			require.FileExists(t, path.Join(dir, "node-2.log"))
+			require.FileExists(t, path.Join(dir, "node-3.log"))
+		})
+	})
+}
+
+func downloadLogs_InteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		dir := check.MustValue(os.MkdirTemp("", "log"))
+		defer func() { check.Must(os.RemoveAll(dir)) }()
+		tcx.WithShell(ctx, func(tcx it.TestContext) {
+			tcx.WithReset(func() {
+				c := createOrGetClusterWithState(ctx, tcx, "")
+				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian download-logs %s -o %s\n", c.Name, dir)))
+				tcx.AssertStderrContains("OK")
+				require.FileExists(t, path.Join(dir, "node-1.log"))
+				require.FileExists(t, path.Join(dir, "node-2.log"))
+				require.FileExists(t, path.Join(dir, "node-3.log"))
+			})
+		})
+	})
+}

--- a/base/commands/viridian/download_logs_it_test.go
+++ b/base/commands/viridian/download_logs_it_test.go
@@ -2,13 +2,12 @@ package viridian_test
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hazelcast/hazelcast-commandline-client/clc/paths"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/check"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/it"
 )
@@ -21,9 +20,9 @@ func downloadLogs_NonInteractiveTest(t *testing.T) {
 		tcx.WithReset(func() {
 			tcx.CLCExecute(ctx, "viridian", "download-logs", c.ID, "--output-dir", dir)
 			tcx.AssertStderrContains("OK")
-			require.FileExists(t, path.Join(dir, "node-1.log"))
-			require.FileExists(t, path.Join(dir, "node-2.log"))
-			require.FileExists(t, path.Join(dir, "node-3.log"))
+			require.FileExists(t, paths.Join(dir, "node-1.log"))
+			require.FileExists(t, paths.Join(dir, "node-2.log"))
+			require.FileExists(t, paths.Join(dir, "node-3.log"))
 		})
 	})
 }
@@ -35,11 +34,11 @@ func downloadLogs_InteractiveTest(t *testing.T) {
 		tcx.WithShell(ctx, func(tcx it.TestContext) {
 			tcx.WithReset(func() {
 				c := createOrGetClusterWithState(ctx, tcx, "")
-				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian download-logs %s -o %s\n", c.Name, dir)))
+				tcx.WriteStdinf("\\viridian download-logs %s -o %s\n", c.Name, dir)
 				tcx.AssertStderrContains("OK")
-				require.FileExists(t, path.Join(dir, "node-1.log"))
-				require.FileExists(t, path.Join(dir, "node-2.log"))
-				require.FileExists(t, path.Join(dir, "node-3.log"))
+				require.FileExists(t, paths.Join(dir, "node-1.log"))
+				require.FileExists(t, paths.Join(dir, "node-2.log"))
+				require.FileExists(t, paths.Join(dir, "node-3.log"))
 			})
 		})
 	})

--- a/base/commands/viridian/viridian_cluster_create.go
+++ b/base/commands/viridian/viridian_cluster_create.go
@@ -44,12 +44,11 @@ func (cm ClusterCreateCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 	}
 	dev := ec.Props().GetBool(flagDevelopment)
 	csi, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
-		sp.SetText("Retrieving available Kubernetes clusters")
+		sp.SetText("Creating the cluster")
 		k8sCluster, err := getFirstAvailableK8sCluster(ctx, api)
 		if err != nil {
 			return nil, err
 		}
-		sp.SetText("Creating the cluster")
 		cs, err := api.CreateCluster(ctx, name, viridian.ClusterPlan(strings.ToUpper(plan)), k8sCluster.ID, dev)
 		if err != nil {
 			return nil, err

--- a/base/commands/viridian/viridian_cluster_create.go
+++ b/base/commands/viridian/viridian_cluster_create.go
@@ -18,11 +18,11 @@ type ClusterCreateCmd struct{}
 
 func (cm ClusterCreateCmd) Init(cc plug.InitContext) error {
 	cc.SetCommandUsage("create-cluster [flags]")
-	long := `Creates a Viridian cluster for the logged in API key.
+	long := `Creates a Viridian cluster.
 
 Make sure you login before running this command.
 `
-	short := "Creates Viridian cluster"
+	short := "Creates a Viridian cluster"
 	cc.SetCommandHelp(long, short)
 	cc.SetPositionalArgCount(0, 0)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
@@ -49,7 +49,7 @@ func (cm ClusterCreateCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 		if err != nil {
 			return nil, err
 		}
-		sp.SetText("Creating a cluster")
+		sp.SetText("Creating the cluster")
 		cs, err := api.CreateCluster(ctx, name, viridian.ClusterPlan(strings.ToUpper(plan)), K8sCluster.ID, dev)
 		if err != nil {
 			return nil, err

--- a/base/commands/viridian/viridian_cluster_create.go
+++ b/base/commands/viridian/viridian_cluster_create.go
@@ -1,0 +1,105 @@
+package viridian
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/output"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/viridian"
+)
+
+type ClusterCreateCmd struct{}
+
+func (cm ClusterCreateCmd) Init(cc plug.InitContext) error {
+	cc.SetCommandUsage("create-cluster [flags]")
+	long := `Creates a Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+`
+	short := "Creates Viridian cluster"
+	cc.SetCommandHelp(long, short)
+	cc.SetPositionalArgCount(0, 0)
+	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
+	cc.AddStringFlag(flagName, "", "", false, "override the cluster name")
+	cc.AddStringFlag(flagPlan, "", "", false, "plan for the cluster, supported values: serverless")
+	cc.AddBoolFlag(flagDevelopment, "", false, false, "start a development cluster")
+	return nil
+}
+
+func (cm ClusterCreateCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
+	api, err := getAPI(ec)
+	if err != nil {
+		return err
+	}
+	name := ec.Props().GetString(flagName)
+	plan := ec.Props().GetString(flagPlan)
+	if err := validatePlan(plan); err != nil {
+		return err
+	}
+	dev := ec.Props().GetBool(flagDevelopment)
+	csi, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
+		sp.SetText("Retrieving available Kubernetes clusters")
+		K8sCluster, err := getFirstAvailableK8sCluster(ctx, api)
+		if err != nil {
+			return nil, err
+		}
+		sp.SetText("Creating a cluster")
+		cs, err := api.CreateCluster(ctx, name, viridian.ClusterPlan(strings.ToUpper(plan)), K8sCluster.ID, dev)
+		if err != nil {
+			return nil, err
+		}
+		return cs, nil
+	})
+	if err != nil {
+		ec.Logger().Error(err)
+		return fmt.Errorf("error creating a cluster. Did you login?: %w", err)
+	}
+	stop()
+	cs := csi.(viridian.Cluster)
+	verbose := ec.Props().GetBool(clc.PropertyVerbose)
+	if verbose {
+		row := output.Row{
+			output.Column{
+				Name:  "ID",
+				Type:  serialization.TypeString,
+				Value: cs.ID,
+			},
+			output.Column{
+				Name:  "Name",
+				Type:  serialization.TypeString,
+				Value: cs.Name,
+			},
+		}
+		return ec.AddOutputRows(ctx, row)
+	}
+	return nil
+}
+
+func validatePlan(plan string) error {
+	switch plan {
+	case "", "serverless":
+		return nil
+	default:
+		return errors.New("plan invalid: possible values: [serverless]")
+	}
+}
+func getFirstAvailableK8sCluster(ctx context.Context, api *viridian.API) (viridian.K8sCluster, error) {
+	clusters, err := api.ListAvailableK8sClusters(ctx)
+	if err != nil {
+		return viridian.K8sCluster{}, err
+	}
+	if len(clusters) == 0 {
+		return viridian.K8sCluster{}, errors.New("there is no available K8s cluster")
+	}
+	return clusters[0], nil
+}
+
+func init() {
+	Must(plug.Registry.RegisterCommand("viridian:cluster-create", &ClusterCreateCmd{}))
+}

--- a/base/commands/viridian/viridian_cluster_create.go
+++ b/base/commands/viridian/viridian_cluster_create.go
@@ -58,7 +58,7 @@ func (cm ClusterCreateCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 	})
 	if err != nil {
 		ec.Logger().Error(err)
-		return fmt.Errorf("error creating a cluster. Did you login?: %w", err)
+		return fmt.Errorf("creating the cluster. Did you login?: %w", err)
 	}
 	stop()
 	cs := csi.(viridian.Cluster)
@@ -86,7 +86,7 @@ func validatePlan(plan string) error {
 	case "", "serverless":
 		return nil
 	default:
-		return errors.New("plan invalid: possible values: [serverless]")
+		return errors.New("invalid plan")
 	}
 }
 func getFirstAvailableK8sCluster(ctx context.Context, api *viridian.API) (viridian.K8sCluster, error) {
@@ -95,11 +95,11 @@ func getFirstAvailableK8sCluster(ctx context.Context, api *viridian.API) (viridi
 		return viridian.K8sCluster{}, err
 	}
 	if len(clusters) == 0 {
-		return viridian.K8sCluster{}, errors.New("there is no available K8s cluster")
+		return viridian.K8sCluster{}, errors.New("cluster creation is not available, try again later")
 	}
 	return clusters[0], nil
 }
 
 func init() {
-	Must(plug.Registry.RegisterCommand("viridian:cluster-create", &ClusterCreateCmd{}))
+	Must(plug.Registry.RegisterCommand("viridian:create-cluster", &ClusterCreateCmd{}))
 }

--- a/base/commands/viridian/viridian_cluster_create.go
+++ b/base/commands/viridian/viridian_cluster_create.go
@@ -26,7 +26,7 @@ Make sure you login before running this command.
 	cc.SetCommandHelp(long, short)
 	cc.SetPositionalArgCount(0, 0)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
-	cc.AddStringFlag(flagName, "", "", false, "override the cluster name")
+	cc.AddStringFlag(flagName, "", "", false, "specify the cluster name; if not given an auto-generated name is used.")
 	cc.AddStringFlag(flagPlan, "", "", false, "plan for the cluster, supported values: serverless")
 	cc.AddBoolFlag(flagDevelopment, "", false, false, "start a development cluster")
 	return nil
@@ -45,12 +45,12 @@ func (cm ClusterCreateCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 	dev := ec.Props().GetBool(flagDevelopment)
 	csi, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
 		sp.SetText("Retrieving available Kubernetes clusters")
-		K8sCluster, err := getFirstAvailableK8sCluster(ctx, api)
+		k8sCluster, err := getFirstAvailableK8sCluster(ctx, api)
 		if err != nil {
 			return nil, err
 		}
 		sp.SetText("Creating the cluster")
-		cs, err := api.CreateCluster(ctx, name, viridian.ClusterPlan(strings.ToUpper(plan)), K8sCluster.ID, dev)
+		cs, err := api.CreateCluster(ctx, name, viridian.ClusterPlan(strings.ToUpper(plan)), k8sCluster.ID, dev)
 		if err != nil {
 			return nil, err
 		}

--- a/base/commands/viridian/viridian_cluster_delete.go
+++ b/base/commands/viridian/viridian_cluster_delete.go
@@ -1,0 +1,66 @@
+package viridian
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	"github.com/hazelcast/hazelcast-commandline-client/errors"
+	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/prompt"
+)
+
+type ClusterDeleteCmd struct{}
+
+func (cm ClusterDeleteCmd) Init(cc plug.InitContext) error {
+	cc.SetCommandUsage("delete-cluster [cluster-ID/name] [flags]")
+	long := `Deletes the given Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+`
+	short := "Deletes Viridian cluster"
+	cc.SetCommandHelp(long, short)
+	cc.SetPositionalArgCount(1, 1)
+	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
+	cc.AddBoolFlag(clc.FlagAutoYes, "", false, false, "skip confirming the delete operation")
+	return nil
+}
+
+func (cm ClusterDeleteCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
+	api, err := getAPI(ec)
+	if err != nil {
+		return err
+	}
+	autoYes := ec.Props().GetBool(clc.FlagAutoYes)
+	if !autoYes {
+		p := prompt.New(ec.Stdin(), ec.Stdout())
+		yes, err := p.YesNo("Cluster will be deleted irreversibly, proceed?")
+		if err != nil {
+			ec.Logger().Info("User input could not be processed due to error: %s", err.Error())
+			return errors.ErrUserCancelled
+		}
+		if !yes {
+			return errors.ErrUserCancelled
+		}
+	}
+	clusterNameOrID := ec.Args()[0]
+	_, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
+		sp.SetText("Deleting the cluster")
+		err := api.DeleteCluster(ctx, clusterNameOrID)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+	if err != nil {
+		ec.Logger().Error(err)
+		return fmt.Errorf("error deleting the cluster. Did you login?: %w", err)
+	}
+	stop()
+	return nil
+}
+
+func init() {
+	Must(plug.Registry.RegisterCommand("viridian:cluster-delete", &ClusterDeleteCmd{}))
+}

--- a/base/commands/viridian/viridian_cluster_delete.go
+++ b/base/commands/viridian/viridian_cluster_delete.go
@@ -15,11 +15,11 @@ type ClusterDeleteCmd struct{}
 
 func (cm ClusterDeleteCmd) Init(cc plug.InitContext) error {
 	cc.SetCommandUsage("delete-cluster [cluster-ID/name] [flags]")
-	long := `Deletes the given Viridian cluster for the logged in API key.
+	long := `Deletes the given Viridian cluster.
 
 Make sure you login before running this command.
 `
-	short := "Deletes Viridian cluster"
+	short := "Deletes the given Viridian cluster"
 	cc.SetCommandHelp(long, short)
 	cc.SetPositionalArgCount(1, 1)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
@@ -62,5 +62,5 @@ func (cm ClusterDeleteCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 }
 
 func init() {
-	Must(plug.Registry.RegisterCommand("viridian:cluster-delete", &ClusterDeleteCmd{}))
+	Must(plug.Registry.RegisterCommand("viridian:delete-cluster", &ClusterDeleteCmd{}))
 }

--- a/base/commands/viridian/viridian_cluster_get.go
+++ b/base/commands/viridian/viridian_cluster_get.go
@@ -16,11 +16,11 @@ type ClusterGetCmd struct{}
 
 func (cm ClusterGetCmd) Init(cc plug.InitContext) error {
 	cc.SetCommandUsage("get-cluster [cluster-ID/name] [flags]")
-	long := `Gets the information about the given Viridian cluster for the logged in API key.
+	long := `Gets the information about the given Viridian cluster.
 
 Make sure you login before running this command.
 `
-	short := "Gets Viridian cluster"
+	short := "Gets the information about the given Viridian cluster"
 	cc.SetCommandHelp(long, short)
 	cc.SetPositionalArgCount(1, 1)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
@@ -43,7 +43,7 @@ func (cm ClusterGetCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	})
 	if err != nil {
 		ec.Logger().Error(err)
-		return fmt.Errorf("error retrieving the cluster. Did you login?: %w", err)
+		return fmt.Errorf("retrieving the cluster. Did you login?: %w", err)
 	}
 	stop()
 	c := ci.(viridian.Cluster)
@@ -73,5 +73,5 @@ func (cm ClusterGetCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 }
 
 func init() {
-	Must(plug.Registry.RegisterCommand("viridian:cluster-get", &ClusterGetCmd{}))
+	Must(plug.Registry.RegisterCommand("viridian:get-cluster", &ClusterGetCmd{}))
 }

--- a/base/commands/viridian/viridian_cluster_get.go
+++ b/base/commands/viridian/viridian_cluster_get.go
@@ -1,0 +1,77 @@
+package viridian
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/output"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/viridian"
+)
+
+type ClusterGetCmd struct{}
+
+func (cm ClusterGetCmd) Init(cc plug.InitContext) error {
+	cc.SetCommandUsage("get-cluster [cluster-ID/name] [flags]")
+	long := `Gets the information about the given Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+`
+	short := "Gets Viridian cluster"
+	cc.SetCommandHelp(long, short)
+	cc.SetPositionalArgCount(1, 1)
+	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
+	return nil
+}
+
+func (cm ClusterGetCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
+	api, err := getAPI(ec)
+	if err != nil {
+		return err
+	}
+	clusterNameOrID := ec.Args()[0]
+	ci, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
+		sp.SetText("Retrieving the cluster")
+		c, err := api.GetCluster(ctx, clusterNameOrID)
+		if err != nil {
+			return nil, err
+		}
+		return c, nil
+	})
+	if err != nil {
+		ec.Logger().Error(err)
+		return fmt.Errorf("error retrieving the cluster. Did you login?: %w", err)
+	}
+	stop()
+	c := ci.(viridian.Cluster)
+	row := output.Row{
+		output.Column{
+			Name:  "ID",
+			Type:  serialization.TypeString,
+			Value: c.ID,
+		},
+		output.Column{
+			Name:  "Name",
+			Type:  serialization.TypeString,
+			Value: c.Name,
+		},
+		output.Column{
+			Name:  "State",
+			Type:  serialization.TypeString,
+			Value: c.State,
+		},
+		output.Column{
+			Name:  "Hazelcast Version",
+			Type:  serialization.TypeString,
+			Value: c.HazelcastVersion,
+		},
+	}
+	return ec.AddOutputRows(ctx, row)
+}
+
+func init() {
+	Must(plug.Registry.RegisterCommand("viridian:cluster-get", &ClusterGetCmd{}))
+}

--- a/base/commands/viridian/viridian_cluster_list.go
+++ b/base/commands/viridian/viridian_cluster_list.go
@@ -78,5 +78,5 @@ func (cm ClusterListCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 }
 
 func init() {
-	Must(plug.Registry.RegisterCommand("viridian:cluster-list", &ClusterListCmd{}))
+	Must(plug.Registry.RegisterCommand("viridian:list-clusters", &ClusterListCmd{}))
 }

--- a/base/commands/viridian/viridian_cluster_list.go
+++ b/base/commands/viridian/viridian_cluster_list.go
@@ -46,6 +46,9 @@ func (cm ClusterListCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	}
 	stop()
 	cs := csi.([]viridian.Cluster)
+	if len(cs) == 0 {
+		ec.PrintlnUnnecessary("No clusters found")
+	}
 	rows := make([]output.Row, len(cs))
 	for i, c := range cs {
 		rows[i] = output.Row{

--- a/base/commands/viridian/viridian_cluster_resume.go
+++ b/base/commands/viridian/viridian_cluster_resume.go
@@ -13,11 +13,11 @@ type ClusterResumeCmd struct{}
 
 func (cm ClusterResumeCmd) Init(cc plug.InitContext) error {
 	cc.SetCommandUsage("resume-cluster [cluster-ID/name] [flags]")
-	long := `Resumes the given Viridian cluster for the logged in API key.
+	long := `Resumes the given Viridian cluster.
 
 Make sure you login before running this command.
 `
-	short := "Resumes Viridian cluster"
+	short := "Resumes the given Viridian cluster"
 	cc.SetCommandHelp(long, short)
 	cc.SetPositionalArgCount(1, 1)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
@@ -47,5 +47,5 @@ func (cm ClusterResumeCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 }
 
 func init() {
-	Must(plug.Registry.RegisterCommand("viridian:cluster-resume", &ClusterResumeCmd{}))
+	Must(plug.Registry.RegisterCommand("viridian:resume-cluster", &ClusterResumeCmd{}))
 }

--- a/base/commands/viridian/viridian_cluster_resume.go
+++ b/base/commands/viridian/viridian_cluster_resume.go
@@ -1,0 +1,51 @@
+package viridian
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
+)
+
+type ClusterResumeCmd struct{}
+
+func (cm ClusterResumeCmd) Init(cc plug.InitContext) error {
+	cc.SetCommandUsage("resume-cluster [cluster-ID/name] [flags]")
+	long := `Resumes the given Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+`
+	short := "Resumes Viridian cluster"
+	cc.SetCommandHelp(long, short)
+	cc.SetPositionalArgCount(1, 1)
+	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
+	return nil
+}
+
+func (cm ClusterResumeCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
+	api, err := getAPI(ec)
+	if err != nil {
+		return err
+	}
+	clusterNameOrID := ec.Args()[0]
+	_, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
+		sp.SetText("Resuming the cluster")
+		err := api.ResumeCluster(ctx, clusterNameOrID)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+	if err != nil {
+		ec.Logger().Error(err)
+		return fmt.Errorf("error resuming the cluster. Did you login?: %w", err)
+	}
+	stop()
+	return nil
+}
+
+func init() {
+	Must(plug.Registry.RegisterCommand("viridian:cluster-resume", &ClusterResumeCmd{}))
+}

--- a/base/commands/viridian/viridian_cluster_stop.go
+++ b/base/commands/viridian/viridian_cluster_stop.go
@@ -13,11 +13,11 @@ type ClusterStopCmd struct{}
 
 func (cm ClusterStopCmd) Init(cc plug.InitContext) error {
 	cc.SetCommandUsage("stop-cluster [cluster-ID/name] [flags]")
-	long := `Stops the given Viridian cluster for the logged in API key.
+	long := `Stops the given Viridian cluster.
 
 Make sure you login before running this command.
 `
-	short := "Stops Viridian cluster"
+	short := "Stops the given Viridian cluster"
 	cc.SetCommandHelp(long, short)
 	cc.SetPositionalArgCount(1, 1)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
@@ -40,12 +40,12 @@ func (cm ClusterStopCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	})
 	if err != nil {
 		ec.Logger().Error(err)
-		return fmt.Errorf("error stopping the cluster. Did you login?: %w", err)
+		return fmt.Errorf("stopping the cluster. Did you login?: %w", err)
 	}
 	stop()
 	return nil
 }
 
 func init() {
-	Must(plug.Registry.RegisterCommand("viridian:cluster-stop", &ClusterStopCmd{}))
+	Must(plug.Registry.RegisterCommand("viridian:stop-cluster", &ClusterStopCmd{}))
 }

--- a/base/commands/viridian/viridian_cluster_stop.go
+++ b/base/commands/viridian/viridian_cluster_stop.go
@@ -1,0 +1,51 @@
+package viridian
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
+)
+
+type ClusterStopCmd struct{}
+
+func (cm ClusterStopCmd) Init(cc plug.InitContext) error {
+	cc.SetCommandUsage("stop-cluster [cluster-ID/name] [flags]")
+	long := `Stops the given Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+`
+	short := "Stops Viridian cluster"
+	cc.SetCommandHelp(long, short)
+	cc.SetPositionalArgCount(1, 1)
+	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
+	return nil
+}
+
+func (cm ClusterStopCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
+	api, err := getAPI(ec)
+	if err != nil {
+		return err
+	}
+	clusterNameOrID := ec.Args()[0]
+	_, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
+		sp.SetText("Stopping the cluster")
+		err := api.StopCluster(ctx, clusterNameOrID)
+		if err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+	if err != nil {
+		ec.Logger().Error(err)
+		return fmt.Errorf("error stopping the cluster. Did you login?: %w", err)
+	}
+	stop()
+	return nil
+}
+
+func init() {
+	Must(plug.Registry.RegisterCommand("viridian:cluster-stop", &ClusterStopCmd{}))
+}

--- a/base/commands/viridian/viridian_it_test.go
+++ b/base/commands/viridian/viridian_it_test.go
@@ -81,7 +81,7 @@ func loginWithParams_InteractiveTest(t *testing.T) {
 		ctx := context.Background()
 		tcx.WithShell(ctx, func(tcx it.TestContext) {
 			tcx.WithReset(func() {
-				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian login --api-key %s --api-secret %s\n", it.ViridianAPIKey(), it.ViridianAPISecret())))
+				tcx.WriteStdinf("\\viridian login --api-key %s --api-secret %s\n", it.ViridianAPIKey(), it.ViridianAPISecret())
 				tcx.AssertStdoutContains("Viridian token was fetched and saved.")
 			})
 		})
@@ -151,7 +151,7 @@ func createCluster_InteractiveTest(t *testing.T) {
 			ensureNoClusterRunning(ctx, tcx)
 			tcx.WithReset(func() {
 				clusterName := it.UniqueClusterName()
-				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian create-cluster --verbose --name %s \n", clusterName)))
+				tcx.WriteStdinf("\\viridian create-cluster --verbose --name %s \n", clusterName)
 				tcx.AssertStderrContains("OK")
 				_ = check.MustValue(tcx.Viridian.GetClusterWithName(ctx, clusterName))
 			})
@@ -173,7 +173,7 @@ func stopCluster_InteractiveTest(t *testing.T) {
 		tcx.WithShell(ctx, func(tcx it.TestContext) {
 			tcx.WithReset(func() {
 				c := createOrGetClusterWithState(ctx, tcx, "RUNNING")
-				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian stop-cluster %s\n", c.Name)))
+				tcx.WriteStdinf("\\viridian stop-cluster %s\n", c.Name)
 				tcx.AssertStderrContains("OK")
 				check.Must(waitState(ctx, tcx, c.ID, "STOPPED"))
 			})
@@ -195,7 +195,7 @@ func resumeCluster_InteractiveTest(t *testing.T) {
 		tcx.WithShell(ctx, func(tcx it.TestContext) {
 			tcx.WithReset(func() {
 				c := createOrGetClusterWithState(ctx, tcx, "STOPPED")
-				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian resume-cluster %s\n", c.Name)))
+				tcx.WriteStdinf("\\viridian resume-cluster %s\n", c.Name)
 				tcx.AssertStderrContains("OK")
 				check.Must(waitState(ctx, tcx, c.ID, "RUNNING"))
 			})
@@ -219,7 +219,7 @@ func getCluster_InteractiveTest(t *testing.T) {
 		tcx.WithShell(ctx, func(tcx it.TestContext) {
 			tcx.WithReset(func() {
 				c := createOrGetClusterWithState(ctx, tcx, "")
-				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian get-cluster %s\n", c.Name)))
+				tcx.WriteStdinf("\\viridian get-cluster %s\n", c.Name)
 				tcx.AssertStderrContains("OK")
 				tcx.AssertStdoutContains(c.Name)
 				tcx.AssertStdoutContains(c.ID)
@@ -246,7 +246,7 @@ func deleteCluster_InteractiveTest(t *testing.T) {
 		tcx.WithShell(ctx, func(tcx it.TestContext) {
 			tcx.WithReset(func() {
 				c := createOrGetClusterWithState(ctx, tcx, "RUNNING")
-				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian delete-cluster %s\n", c.Name)))
+				tcx.WriteStdinf("\\viridian delete-cluster %s\n", c.Name)
 				tcx.AssertStdoutContains("(y/n)")
 				tcx.WriteStdin([]byte("y"))
 				tcx.AssertStderrContains("OK")

--- a/base/commands/viridian/viridian_it_test.go
+++ b/base/commands/viridian/viridian_it_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hazelcast/hazelcast-commandline-client/internal/check"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/it"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/viridian"
+	"github.com/stretchr/testify/require"
 )
 
 func TestViridian(t *testing.T) {
@@ -28,7 +29,6 @@ func TestViridian(t *testing.T) {
 				if err := tcx.Viridian.DeleteCluster(ctx, info.ID); err != nil {
 					tcx.T.Logf("ERROR while cleaning up cluster: %s", err.Error())
 				}
-
 			}
 		})
 	}()
@@ -36,12 +36,24 @@ func TestViridian(t *testing.T) {
 		name string
 		f    func(t *testing.T)
 	}{
-		{"listClustersNonInteractive", listClusters_NonInteractiveTest},
-		{"istClusters_Interactive", listClusters_InteractiveTest},
-		{"loginWithEnvVariables_NonInteractive", loginWithEnvVariables_NonInteractiveTest},
 		{"loginWithParams_NonInteractive", loginWithParams_NonInteractiveTest},
 		{"loginWithParams_Interactive", loginWithParams_InteractiveTest},
+		{"loginWithEnvVariables_NonInteractive", loginWithEnvVariables_NonInteractiveTest},
+		{"createCluster_NonInteractive", createCluster_NonInteractiveTest},
+		{"stopCluster_NonInteractive", stopCluster_NonInteractiveTest},
+		{"resumeCluster_NonInteractive", resumeCluster_NonInteractiveTest},
+		{"stopCluster_Interactive", stopCluster_InteractiveTest},
+		{"resumeCluster_Interactive", resumeCluster_InteractiveTest},
+		{"getCluster_NonInteractive", getCluster_NonInteractiveTest},
+		{"getCluster_InteractiveTest", getCluster_InteractiveTest},
+		{"listClusters_NonInteractive", listClusters_NonInteractiveTest},
+		{"listClusters_Interactive", listClusters_InteractiveTest},
+		{"downloadLogs_NonInteractive", downloadLogs_NonInteractiveTest},
+		{"downloadLogs_Interactive", downloadLogs_InteractiveTest},
 		{"customClass_NonInteractive", customClass_NonInteractiveTest},
+		{"deleteCluster_NonInteractive", deleteCluster_NonInteractiveTest},
+		{"createCluster_Interactive", createCluster_InteractiveTest},
+		{"deleteCluster_Interactive", deleteCluster_InteractiveTest},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, tc.f)
@@ -96,10 +108,10 @@ func listClusters_NonInteractiveTest(t *testing.T) {
 	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
 		tcx.CLCExecute(ctx, "viridian", "list-clusters")
 		tcx.AssertStderrContains("OK")
-		cid := ensureClusterRunning(ctx, tcx)
+		c := createOrGetClusterWithState(ctx, tcx, "RUNNING")
 		tcx.CLCExecute(ctx, "viridian", "list-clusters")
 		tcx.AssertStderrContains("OK")
-		tcx.AssertStdoutContains(cid)
+		tcx.AssertStdoutContains(c.ID)
 	})
 }
 
@@ -110,11 +122,132 @@ func listClusters_InteractiveTest(t *testing.T) {
 				tcx.WriteStdin([]byte("\\viridian list-clusters\n"))
 				tcx.AssertStderrContains("OK")
 			})
-			cid := ensureClusterRunning(ctx, tcx)
+			c := createOrGetClusterWithState(ctx, tcx, "RUNNING")
 			tcx.WithReset(func() {
 				tcx.WriteStdin([]byte("\\viridian list-clusters\n"))
 				tcx.AssertStderrContains("OK")
-				tcx.AssertStdoutContains(cid)
+				tcx.AssertStdoutContains(c.ID)
+			})
+		})
+	})
+}
+
+func createCluster_NonInteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		ensureNoClusterRunning(ctx, tcx)
+		clusterName := it.UniqueClusterName()
+		tcx.CLCExecute(ctx, "viridian", "create-cluster", "--verbose", "--name", clusterName)
+		tcx.AssertStderrContains("OK")
+		fields := tcx.AssertStdoutHasRowWithFields("ID", "Name")
+		info := check.MustValue(tcx.Viridian.GetCluster(ctx, fields["ID"]))
+		require.Equal(t, info.Name, clusterName)
+		waitState(ctx, tcx, info.ID, "RUNNING")
+	})
+}
+
+func createCluster_InteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		tcx.WithShell(ctx, func(tcx it.TestContext) {
+			ensureNoClusterRunning(ctx, tcx)
+			tcx.WithReset(func() {
+				tcx.WriteStdin([]byte("\\viridian create-cluster --verbose \n"))
+				tcx.AssertStderrContains("OK")
+				fields := tcx.AssertStdoutHasRowWithFields("ID", "Name")
+				info := check.MustValue(tcx.Viridian.GetCluster(ctx, fields["ID"]))
+				waitState(ctx, tcx, info.ID, "RUNNING")
+			})
+		})
+	})
+}
+
+func stopCluster_NonInteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		c := createOrGetClusterWithState(ctx, tcx, "RUNNING")
+		tcx.CLCExecute(ctx, "viridian", "stop-cluster", c.ID)
+		tcx.AssertStderrContains("OK")
+		check.Must(waitState(ctx, tcx, c.ID, "STOPPED"))
+	})
+}
+
+func stopCluster_InteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		tcx.WithShell(ctx, func(tcx it.TestContext) {
+			tcx.WithReset(func() {
+				c := createOrGetClusterWithState(ctx, tcx, "RUNNING")
+				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian stop-cluster %s\n", c.Name)))
+				tcx.AssertStderrContains("OK")
+				check.Must(waitState(ctx, tcx, c.ID, "STOPPED"))
+			})
+		})
+	})
+}
+
+func resumeCluster_NonInteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		c := createOrGetClusterWithState(ctx, tcx, "STOPPED")
+		tcx.CLCExecute(ctx, "viridian", "resume-cluster", c.ID)
+		tcx.AssertStderrContains("OK")
+		check.Must(waitState(ctx, tcx, c.ID, "RUNNING"))
+	})
+}
+
+func resumeCluster_InteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		tcx.WithShell(ctx, func(tcx it.TestContext) {
+			tcx.WithReset(func() {
+				c := createOrGetClusterWithState(ctx, tcx, "STOPPED")
+				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian resume-cluster %s\n", c.Name)))
+				tcx.AssertStderrContains("OK")
+				check.Must(waitState(ctx, tcx, c.ID, "RUNNING"))
+			})
+		})
+	})
+}
+
+func getCluster_NonInteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		c := createOrGetClusterWithState(ctx, tcx, "")
+		tcx.CLCExecute(ctx, "viridian", "get-cluster", c.ID, "--verbose")
+		tcx.AssertStderrContains("OK")
+		fields := tcx.AssertStdoutHasRowWithFields("ID", "Name", "State", "Version")
+		require.Equal(t, c.ID, fields["ID"])
+		require.Equal(t, c.Name, fields["Name"])
+	})
+}
+
+func getCluster_InteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		tcx.WithShell(ctx, func(tcx it.TestContext) {
+			tcx.WithReset(func() {
+				c := createOrGetClusterWithState(ctx, tcx, "")
+				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian get-cluster %s\n", c.Name)))
+				tcx.AssertStderrContains("OK")
+				tcx.AssertStdoutContains(c.Name)
+				tcx.AssertStdoutContains(c.ID)
+			})
+		})
+	})
+}
+
+func deleteCluster_NonInteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		c := createOrGetClusterWithState(ctx, tcx, "")
+		tcx.CLCExecute(ctx, "viridian", "delete-cluster", c.ID)
+		tcx.AssertStderrContains("OK")
+		_, err := tcx.Viridian.GetCluster(ctx, c.ID)
+		require.ErrorContains(t, err, "no such cluster found")
+	})
+}
+
+func deleteCluster_InteractiveTest(t *testing.T) {
+	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
+		tcx.WithShell(ctx, func(tcx it.TestContext) {
+			tcx.WithReset(func() {
+				c := createOrGetClusterWithState(ctx, tcx, "")
+				tcx.WriteStdin([]byte(fmt.Sprintf("\\viridian delete-cluster %s\n", c.Name)))
+				tcx.AssertStderrContains("OK")
+				_, err := tcx.Viridian.GetCluster(ctx, c.ID)
+				require.ErrorContains(t, err, "no such cluster found")
 			})
 		})
 	})
@@ -135,18 +268,50 @@ func viridianTester(t *testing.T, f func(ctx context.Context, tcx it.TestContext
 	})
 }
 
-func ensureClusterRunning(ctx context.Context, tcx it.TestContext) string {
+func createOrGetClusterWithState(ctx context.Context, tcx it.TestContext, wantedState string) it.ViridianClusterInfo {
 	info, err := tcx.Viridian.CreateCluster(ctx, it.UniqueClusterName())
 	if err != nil {
 		tcx.T.Logf("Ignoring error: %s", err.Error())
 		infos := check.MustValue(tcx.Viridian.ListClusters(ctx))
 		info = infos[0]
 	}
-	tcx.T.Logf("cluster %s, state: %s", info.ID, info.State)
-	if info.State != "RUNNING" {
+	if wantedState == "" || info.State == wantedState {
+		return info
+	}
+	if wantedState == "RUNNING" {
+		switch info.State {
+		case "STOPPED":
+			check.Must(tcx.Viridian.ResumeCluster(ctx, info.ID))
+		case "STOP_IN_PROGRESS":
+			check.Must(waitState(ctx, tcx, info.ID, "STOPPED"))
+			check.Must(tcx.Viridian.ResumeCluster(ctx, info.ID))
+		}
 		check.Must(waitState(ctx, tcx, info.ID, "RUNNING"))
 	}
-	return info.ID
+	if wantedState == "STOPPED" {
+		switch info.State {
+		case "PENDING":
+			check.Must(waitState(ctx, tcx, info.ID, "RUNNING"))
+			check.Must(tcx.Viridian.StopCluster(ctx, info.ID))
+		case "RUNNING":
+			check.Must(tcx.Viridian.StopCluster(ctx, info.ID))
+		case "RESUME_IN_PROGRESS":
+			check.Must(waitState(ctx, tcx, info.ID, "RUNNING"))
+			check.Must(tcx.Viridian.StopCluster(ctx, info.ID))
+		}
+		check.Must(waitState(ctx, tcx, info.ID, "STOPPED"))
+	}
+	return check.MustValue(tcx.Viridian.GetCluster(ctx, info.ID))
+}
+
+func ensureNoClusterRunning(ctx context.Context, tcx it.TestContext) {
+	infos := check.MustValue(tcx.Viridian.ListClusters(ctx))
+	for _, info := range infos {
+		if info.State == "PENDING" {
+			check.Must(waitState(ctx, tcx, info.ID, "RUNNING"))
+		}
+		check.Must(tcx.Viridian.DeleteCluster(ctx, info.ID))
+	}
 }
 
 func waitState(ctx context.Context, tcx it.TestContext, clusterID, state string) error {

--- a/docs/modules/ROOT/pages/clc-viridian.adoc
+++ b/docs/modules/ROOT/pages/clc-viridian.adoc
@@ -15,9 +15,9 @@ clc viridian [command] [options]
 * <<clc-viridian-create-cluster, clc viridian create-cluster>>
 * <<clc-viridian-get-cluster, clc viridian get-cluster>>
 * <<clc-viridian-list-clusters, clc viridian list-clusters>>
-* <<clc-viridian-stop-cluster, clc viridian get-cluster>>
-* <<clc-viridian-resume-cluster, clc viridian get-cluster>>
-* <<clc-viridian-delete-cluster, clc viridian get-cluster>>
+* <<clc-viridian-stop-cluster, clc viridian stop-cluster>>
+* <<clc-viridian-resume-cluster, clc viridian resume-cluster>>
+* <<clc-viridian-delete-cluster, clc viridian delete-cluster>>
 * <<clc-viridian-download-logs, clc viridian download-logs>>
 * <<clc-viridian-list-custom-classes, clc viridian list-custom-classes>>
 * <<clc-viridian-upload-custom-class, clc viridian upload-custom-class>>
@@ -62,7 +62,7 @@ Parameters:
 
 == clc viridian create-cluster
 
-Creates a Viridian cluster for the logged in API key.
+Creates a Viridian cluster.
 
 Make sure you login before running this command.
 
@@ -86,7 +86,7 @@ Parameters:
 
 |`--name`
 |Optional
-|Sets the name of the created cluster. If not given, random name will be generated.
+|Sets the name of the created cluster. If not given, an auto-generated name will be used.
 |
 
 |`--plan`
@@ -102,7 +102,7 @@ Parameters:
 
 == clc viridian get-cluster
 
-Gets the information about the given Viridian cluster for the logged in API key.
+Gets the information about the given Viridian cluster.
 
 Make sure you login before running this command.
 
@@ -154,7 +154,7 @@ Parameters:
 
 == clc viridian stop-cluster
 
-Stops the given Viridian cluster for the logged in API key.
+Stops the given Viridian cluster.
 
 Make sure you login before running this command.
 
@@ -180,7 +180,7 @@ Parameters:
 
 == clc viridian resume-cluster
 
-Resumes the given Viridian cluster for the logged in API key.
+Resumes the given Viridian cluster.
 
 Make sure you login before running this command.
 
@@ -206,7 +206,7 @@ Parameters:
 
 == clc viridian delete-cluster
 
-Deletes the given Viridian cluster for the logged in API key.
+Deletes the given Viridian cluster.
 
 Make sure you login before running this command.
 
@@ -237,7 +237,7 @@ Parameters:
 
 == clc viridian download-logs
 
-Downloads the logs of the given Viridian cluster for the logged in API key.
+Downloads the logs of the given Viridian cluster.
 
 Make sure you login before running this command.
 

--- a/docs/modules/ROOT/pages/clc-viridian.adoc
+++ b/docs/modules/ROOT/pages/clc-viridian.adoc
@@ -12,7 +12,13 @@ clc viridian [command] [options]
 == Commands
 
 * <<clc-viridian-login, clc viridian login>>
+* <<clc-viridian-create-cluster, clc viridian create-cluster>>
+* <<clc-viridian-get-cluster, clc viridian get-cluster>>
 * <<clc-viridian-list-clusters, clc viridian list-clusters>>
+* <<clc-viridian-stop-cluster, clc viridian get-cluster>>
+* <<clc-viridian-resume-cluster, clc viridian get-cluster>>
+* <<clc-viridian-delete-cluster, clc viridian get-cluster>>
+* <<clc-viridian-download-logs, clc viridian download-logs>>
 * <<clc-viridian-list-custom-classes, clc viridian list-custom-classes>>
 * <<clc-viridian-upload-custom-class, clc viridian upload-custom-class>>
 * <<clc-viridian-download-custom-class, clc viridian download-custom-class>>
@@ -54,6 +60,72 @@ Parameters:
 
 |===
 
+== clc viridian create-cluster
+
+Creates a Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+
+Usage:
+
+[source,bash]
+----
+clc viridian create-cluster [flags]
+----
+
+Parameters:
+
+[cols="1m,1a,2a,1a"]
+|===
+|Parameter|Required|Description|Default
+
+|`--api-key`
+|Optional
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|
+
+|`--name`
+|Optional
+|Sets the name of the created cluster. If not given, random name will be generated.
+|
+
+|`--plan`
+|Optional
+|Sets the plan for the created cluster.
+|serverless
+
+|`--development`
+|Optional
+|Creates a development cluster.
+|false
+|===
+
+== clc viridian get-cluster
+
+Gets the information about the given Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+
+Usage:
+
+[source,bash]
+----
+clc viridian get-cluster [cluster-ID/name] [flags]
+----
+
+Parameters:
+
+[cols="1m,1a,2a,1a"]
+|===
+|Parameter|Required|Description|Default
+
+|`--api-key`
+|Optional
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|
+
+|===
+
 == clc viridian list-clusters
 
 Lists all Viridian clusters for the logged in API key.
@@ -66,6 +138,135 @@ Usage:
 ----
 clc viridian list-clusters [flags]
 ----
+
+Parameters:
+
+[cols="1m,1a,2a,1a"]
+|===
+|Parameter|Required|Description|Default
+
+|`--api-key`
+|Optional
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|
+
+|===
+
+== clc viridian stop-cluster
+
+Stops the given Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+
+Usage:
+
+[source,bash]
+----
+clc viridian stop-cluster [cluster-ID/name] [flags]
+----
+
+Parameters:
+
+[cols="1m,1a,2a,1a"]
+|===
+|Parameter|Required|Description|Default
+
+|`--api-key`
+|Optional
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|
+
+|===
+
+== clc viridian resume-cluster
+
+Resumes the given Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+
+Usage:
+
+[source,bash]
+----
+clc viridian resume-cluster [cluster-ID/name] [flags]
+----
+
+Parameters:
+
+[cols="1m,1a,2a,1a"]
+|===
+|Parameter|Required|Description|Default
+
+|`--api-key`
+|Optional
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|
+
+|===
+
+== clc viridian delete-cluster
+
+Deletes the given Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+
+Usage:
+
+[source,bash]
+----
+clc viridian delete-cluster [cluster-ID/name] [flags]
+----
+
+Parameters:
+
+[cols="1m,1a,2a,1a"]
+|===
+|Parameter|Required|Description|Default
+
+|`--api-key`
+|Optional
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|
+
+|`--yes`
+|Optional
+|Skips confirming the delete operation.
+|
+
+|===
+
+== clc viridian download-logs
+
+Downloads the logs of the given Viridian cluster for the logged in API key.
+
+Make sure you login before running this command.
+
+Usage:
+
+[source,bash]
+----
+clc viridian download-logs [cluster-ID/name] [flags]
+----
+
+Parameters:
+
+[cols="1m,1a,2a,1a"]
+|===
+|Parameter|Required|Description|Default
+
+|`--api-key`
+|Optional
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|
+
+|`--output-dir` `-o`
+|Optional
+|Output directory for the log files, if not given current directory is used.
+|
+
+|===
+
+
 
 == clc viridian list-custom-classes
 

--- a/go.mod
+++ b/go.mod
@@ -51,8 +51,8 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
-	golang.org/x/text v0.4.0 // indirect
+	golang.org/x/term v0.4.0 // indirect
+	golang.org/x/text v0.6.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -150,11 +150,12 @@ golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.4.0 h1:O7UWfv5+A2qiuulQk30kVinPoMtoIPeVaKLEgLpVkvg=
+golang.org/x/term v0.4.0/go.mod h1:9P2UbLfCdcvo3p/nzKvsmas4TnlujnuoV9hGgYzW1lQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
-golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.6.0 h1:3XmdazWV+ubf7QgHSTWeykHOci5oeekaGJBLkrkaw4k=
+golang.org/x/text v0.6.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/internal/it/test_cluster.go
+++ b/internal/it/test_cluster.go
@@ -192,6 +192,19 @@ func (a *ViridianAPI) GetCluster(ctx context.Context, clusterID string) (Viridia
 	return res, nil
 }
 
+func (a *ViridianAPI) GetClusterWithName(ctx context.Context, name string) (ViridianClusterInfo, error) {
+	cs, err := a.ListClusters(ctx)
+	if err != nil {
+		return ViridianClusterInfo{}, err
+	}
+	for _, c := range cs {
+		if c.Name == name {
+			return c, nil
+		}
+	}
+	return ViridianClusterInfo{}, errors.New("cluster does not exist")
+}
+
 func (a *ViridianAPI) ListClusters(ctx context.Context) ([]ViridianClusterInfo, error) {
 	res, err := doGet[Wrapper[[]ViridianClusterInfo]](ctx, "/cluster", a.token)
 	if err != nil {

--- a/internal/it/test_cluster.go
+++ b/internal/it/test_cluster.go
@@ -219,7 +219,7 @@ func (a *ViridianAPI) StopCluster(ctx context.Context, id string) error {
 		return err
 	}
 	if !ok {
-		return errors.New("stopping cluster returned false")
+		return errors.New("could not stop the cluster")
 	}
 	return nil
 }
@@ -230,7 +230,7 @@ func (a *ViridianAPI) ResumeCluster(ctx context.Context, id string) error {
 		return err
 	}
 	if !ok {
-		return errors.New("resuming cluster returned false")
+		return errors.New("could not resume the cluster")
 	}
 	return nil
 }

--- a/internal/it/test_cluster.go
+++ b/internal/it/test_cluster.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -131,8 +132,9 @@ func XMLConfig(clusterName string, port int) string {
 	`, clusterName, port)
 }
 
-type viridianClusterInfo struct {
+type ViridianClusterInfo struct {
 	ID    string `json:"id"`
+	Name  string `json:"name"`
 	State string `json:"state"`
 }
 
@@ -164,16 +166,16 @@ func (a *ViridianAPI) login(ctx context.Context, apiKey, apiSecret string) {
 	a.token = res["token"].(string)
 }
 
-func (a *ViridianAPI) CreateCluster(ctx context.Context, name string) (viridianClusterInfo, error) {
+func (a *ViridianAPI) CreateCluster(ctx context.Context, name string) (ViridianClusterInfo, error) {
 	req := map[string]any{
 		"kubernetesClusterId": 1,
 		"clusterTypeId":       6,
 		"name":                name,
 		"planName":            "SERVERLESS",
 	}
-	res, err := doPost[keyValue, viridianClusterInfo](ctx, "/cluster", a.token, req)
+	res, err := doPost[keyValue, ViridianClusterInfo](ctx, "/cluster", a.token, req)
 	if err != nil {
-		return viridianClusterInfo{}, err
+		return ViridianClusterInfo{}, err
 	}
 	return res, nil
 }
@@ -182,12 +184,42 @@ func (a *ViridianAPI) DeleteCluster(ctx context.Context, clusterID string) error
 	return doDelete(ctx, "/cluster/"+clusterID, a.token)
 }
 
-func (a *ViridianAPI) ListClusters(ctx context.Context) ([]viridianClusterInfo, error) {
-	res, err := doGet[Wrapper[[]viridianClusterInfo]](ctx, "/cluster", a.token)
+func (a *ViridianAPI) GetCluster(ctx context.Context, clusterID string) (ViridianClusterInfo, error) {
+	res, err := doGet[ViridianClusterInfo](ctx, "/cluster/"+clusterID, a.token)
+	if err != nil {
+		return ViridianClusterInfo{}, err
+	}
+	return res, nil
+}
+
+func (a *ViridianAPI) ListClusters(ctx context.Context) ([]ViridianClusterInfo, error) {
+	res, err := doGet[Wrapper[[]ViridianClusterInfo]](ctx, "/cluster", a.token)
 	if err != nil {
 		return nil, err
 	}
 	return res.Content, nil
+}
+
+func (a *ViridianAPI) StopCluster(ctx context.Context, id string) error {
+	ok, err := doPost[[]byte, bool](ctx, fmt.Sprintf("/cluster/%s/stop", id), a.token, nil)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("stopping cluster returned false")
+	}
+	return nil
+}
+
+func (a *ViridianAPI) ResumeCluster(ctx context.Context, id string) error {
+	ok, err := doPost[[]byte, bool](ctx, fmt.Sprintf("/cluster/%s/resume", id), a.token, nil)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("resuming cluster returned false")
+	}
+	return nil
 }
 
 func makeUrl(path string) string {

--- a/internal/it/test_context.go
+++ b/internal/it/test_context.go
@@ -257,6 +257,20 @@ func (tcx TestContext) AssertStdoutDollar(text string) {
 	}
 }
 
+func (tcx TestContext) AssertStdoutHasRowWithFields(fields ...string) map[string]string {
+	stdout := string(tcx.ExpectStdout.String())
+	out := strings.Fields(stdout)
+	if len(fields) != len(out) {
+		tcx.T.Log("STDOUT:", stdout)
+		tcx.T.Fatalf("stdout does not have the same fields as %v", fields)
+	}
+	fm := map[string]string{}
+	for i, f := range fields {
+		fm[f] = out[i]
+	}
+	return fm
+}
+
 func (tcx TestContext) AssertStdoutDollarWithPath(path string) {
 	p := string(check.MustValue(os.ReadFile(path)))
 	tcx.AssertStdoutDollar(p)

--- a/internal/viridian/api.go
+++ b/internal/viridian/api.go
@@ -218,8 +218,8 @@ func doPostBytes(ctx context.Context, url, token string, body []byte) ([]byte, e
 	return nil, fmt.Errorf("%d: %s", res.StatusCode, string(rb))
 }
 
-func doDelete(ctx context.Context, url, token string) error {
-	req, err := http.NewRequest(http.MethodDelete, makeUrl(url), nil)
+func doDelete(ctx context.Context, path, token string) error {
+	req, err := http.NewRequest(http.MethodDelete, makeUrl(path), nil)
 	if err != nil {
 		return fmt.Errorf("creating request: %w", err)
 	}

--- a/internal/viridian/cluster.go
+++ b/internal/viridian/cluster.go
@@ -67,7 +67,7 @@ func (a API) StopCluster(ctx context.Context, idOrName string) error {
 		return fmt.Errorf("stopping cluster: %w", err)
 	}
 	if !ok {
-		return errors.New("stopping cluster returned false")
+		return errors.New("could not stop the cluster")
 	}
 	return nil
 }
@@ -90,7 +90,7 @@ func (a API) ResumeCluster(ctx context.Context, idOrName string) error {
 		return fmt.Errorf("resuming cluster: %w", err)
 	}
 	if !ok {
-		return errors.New("resuming cluster returned false")
+		return errors.New("could not resume the cluster")
 	}
 	return nil
 }

--- a/internal/viridian/cluster.go
+++ b/internal/viridian/cluster.go
@@ -22,9 +22,6 @@ type createClusterResponse Cluster
 func (a API) CreateCluster(ctx context.Context, name string, plan ClusterPlan, k8sClusterID int, isDev bool) (Cluster, error) {
 	if name == "" {
 		name = clusterName()
-		if name == "" {
-			return Cluster{}, errors.New("could not generate cluster name")
-		}
 	}
 	if plan == "" {
 		plan = ClusterPlanServerless
@@ -49,7 +46,7 @@ func (a API) CreateCluster(ctx context.Context, name string, plan ClusterPlan, k
 func clusterName() string {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return ""
+		cwd = "cluster"
 	}
 	base := path.Base(cwd)
 	date := time.Now().Format("2006-01-02-15-04-05")

--- a/internal/viridian/cluster.go
+++ b/internal/viridian/cluster.go
@@ -1,0 +1,120 @@
+package viridian
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"path"
+	"time"
+)
+
+type createClusterRequest struct {
+	KubernetesClusterID int         `json:"kubernetesClusterId"`
+	Name                string      `json:"name"`
+	ClusterTypeID       ClusterType `json:"clusterTypeId"`
+	PlanName            ClusterPlan `json:"planName"`
+}
+
+type createClusterResponse Cluster
+
+func (a API) CreateCluster(ctx context.Context, name string, plan ClusterPlan, k8sClusterID int, isDev bool) (Cluster, error) {
+	if name == "" {
+		name = clusterName()
+		if name == "" {
+			return Cluster{}, errors.New("could not generate cluster name")
+		}
+	}
+	if plan == "" {
+		plan = ClusterPlanServerless
+	}
+	ct := ClusterTypeProd
+	if isDev {
+		ct = ClusterTypeDev
+	}
+	c := createClusterRequest{
+		KubernetesClusterID: k8sClusterID,
+		Name:                name,
+		ClusterTypeID:       ct,
+		PlanName:            plan,
+	}
+	cluster, err := doPost[createClusterRequest, createClusterResponse](ctx, "/cluster", a.Token(), c)
+	if err != nil {
+		return Cluster{}, fmt.Errorf("creating cluster: %w", err)
+	}
+	return Cluster(cluster), nil
+}
+
+func clusterName() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	base := path.Base(cwd)
+	date := time.Now().Format("2006-01-02-15-04-05")
+	num := rand.Intn(9999)
+	return fmt.Sprintf("%s-%s-%.4d", base, date, num)
+}
+
+func (a API) StopCluster(ctx context.Context, idOrName string) error {
+	cid, err := a.findClusterID(ctx, idOrName)
+	if err != nil {
+		return err
+	}
+	ok, err := doPost[[]byte, bool](ctx, fmt.Sprintf("/cluster/%s/stop", cid), a.Token(), nil)
+	if err != nil {
+		return fmt.Errorf("stopping cluster: %w", err)
+	}
+	if !ok {
+		return errors.New("stopping cluster returned false")
+	}
+	return nil
+}
+
+func (a API) ListClusters(ctx context.Context) ([]Cluster, error) {
+	csw, err := doGet[Wrapper[[]Cluster]](ctx, "/cluster", a.Token())
+	if err != nil {
+		return nil, fmt.Errorf("listing clusters: %w", err)
+	}
+	return csw.Content, nil
+}
+
+func (a API) ResumeCluster(ctx context.Context, idOrName string) error {
+	cid, err := a.findClusterID(ctx, idOrName)
+	if err != nil {
+		return err
+	}
+	ok, err := doPost[[]byte, bool](ctx, fmt.Sprintf("/cluster/%s/resume", cid), a.Token(), nil)
+	if err != nil {
+		return fmt.Errorf("resuming cluster: %w", err)
+	}
+	if !ok {
+		return errors.New("resuming cluster returned false")
+	}
+	return nil
+}
+
+func (a API) DeleteCluster(ctx context.Context, idOrName string) error {
+	cid, err := a.findClusterID(ctx, idOrName)
+	if err != nil {
+		return err
+	}
+	err = doDelete(ctx, fmt.Sprintf("/cluster/%s", cid), a.Token())
+	if err != nil {
+		return fmt.Errorf("deleting cluster: %w", err)
+	}
+	return nil
+}
+
+func (a API) GetCluster(ctx context.Context, idOrName string) (Cluster, error) {
+	cid, err := a.findClusterID(ctx, idOrName)
+	if err != nil {
+		return Cluster{}, err
+	}
+	c, err := doGet[Cluster](ctx, fmt.Sprintf("/cluster/%s", cid), a.Token())
+	if err != nil {
+		return Cluster{}, fmt.Errorf("retrieving cluster: %w", err)
+	}
+	return c, nil
+}

--- a/internal/viridian/cluster_log.go
+++ b/internal/viridian/cluster_log.go
@@ -1,0 +1,115 @@
+package viridian
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+)
+
+func (a API) DownloadClusterLogs(ctx context.Context, destDir string, idOrName string) error {
+	cid, err := a.findClusterID(ctx, idOrName)
+	if err != nil {
+		return err
+	}
+	err = downloadLogs(ctx, destDir, fmt.Sprintf("/cluster/%s/logs", cid), a.token)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func downloadLogs(ctx context.Context, destDir string, url, token string) error {
+	req, err := http.NewRequest(http.MethodGet, makeUrl(url), nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req = req.WithContext(ctx)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending request: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("status code is: %d", res.StatusCode)
+	}
+	tempZip, err := saveTempFile("logzip", res.Body)
+	if err != nil {
+		return fmt.Errorf("creating temp zip file: %w", err)
+	}
+	defer tempZip.Close()
+	err = unzip(tempZip, destDir)
+	if err != nil {
+		return fmt.Errorf("unzipping: %w", err)
+	}
+	return nil
+}
+
+func saveTempFile(name string, r io.Reader) (*os.File, error) {
+	tempFile, err := os.CreateTemp("", name)
+	if err != nil {
+		return nil, err
+	}
+	_, err = io.Copy(tempFile, r)
+	if err != nil {
+		return nil, err
+	}
+	return tempFile, nil
+}
+
+func unzip(zipFile *os.File, destDir string) error {
+	fi, err := zipFile.Stat()
+	if err != nil {
+		return err
+	}
+	zipReader, err := zip.NewReader(zipFile, fi.Size())
+	if err != nil {
+		return err
+	}
+
+	if destDir == "" {
+		dir, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		destDir = dir
+	}
+
+	err = os.MkdirAll(destDir, 0700)
+	if err != nil {
+		return err
+	}
+	for _, file := range zipReader.File {
+		r, err := file.Open()
+		if err != nil {
+			return err
+		}
+		filePath := path.Join(destDir, file.Name)
+		err = saveFile(filePath, file.FileInfo(), r)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func saveFile(name string, info fs.FileInfo, src io.Reader) error {
+	if info.IsDir() {
+		return os.MkdirAll(name, info.Mode())
+	}
+	dst, err := os.OpenFile(name, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+	_, err = io.Copy(dst, src)
+	return err
+}

--- a/internal/viridian/cluster_log.go
+++ b/internal/viridian/cluster_log.go
@@ -43,7 +43,7 @@ func downloadLogs(ctx context.Context, destDir string, url, token string) error 
 	}
 	tempZip, err := saveTempFile("logzip", res.Body)
 	if err != nil {
-		return fmt.Errorf("creating temp zip file: %w", err)
+		return fmt.Errorf("creating temporary  file: %w", err)
 	}
 	defer tempZip.Close()
 	err = unzip(tempZip, destDir)

--- a/internal/viridian/types.go
+++ b/internal/viridian/types.go
@@ -14,3 +14,20 @@ type CustomClass struct {
 	Status                   string `json:"status"`
 	TemporaryCustomClassesId string `json:"temporaryCustomClassesId"`
 }
+
+type K8sCluster struct {
+	ID int `json:"id"`
+}
+
+type ClusterType int
+
+const (
+	ClusterTypeDev  ClusterType = 6
+	ClusterTypeProd ClusterType = 5
+)
+
+type ClusterPlan string
+
+const (
+	ClusterPlanServerless ClusterPlan = "SERVERLESS"
+)


### PR DESCRIPTION
Following commands are added to `viridian`

- create-cluster
- delete-cluster
- stop-cluster
- resume-cluster
- get-cluster
- download-logs