### PR TITLE
[CLC-170] Viridian Command Updates

### DIFF
--- a/base/commands/viridian/common.go
+++ b/base/commands/viridian/common.go
@@ -1,12 +1,14 @@
 package viridian
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc/secrets"
+	errors2 "github.com/hazelcast/hazelcast-commandline-client/errors"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/viridian"
 )
@@ -52,4 +54,16 @@ func getAPI(ec plug.ExecContext) (*viridian.API, error) {
 		return nil, fmt.Errorf("could not load Viridian secrets, did you login?")
 	}
 	return viridian.NewAPI(string(token)), nil
+}
+
+func handleErrorResponse(ec plug.ExecContext, err error) error {
+	// log the original error in very case
+	ec.Logger().Error(err)
+	// if it is a http client error, return the simplified error to user
+	var err2 errors2.HTTPClientError
+	if errors.As(err, &err2) {
+		return fmt.Errorf(err2.Text())
+	}
+	// if it is not a http client error, return it directly as always
+	return err
 }

--- a/base/commands/viridian/common.go
+++ b/base/commands/viridian/common.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc/secrets"
-	errors2 "github.com/hazelcast/hazelcast-commandline-client/errors"
+	hzerrors "github.com/hazelcast/hazelcast-commandline-client/errors"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/viridian"
 )
@@ -105,10 +105,9 @@ func matchClusterState(cluster viridian.Cluster, state string) (bool, error) {
 }
 
 func handleErrorResponse(ec plug.ExecContext, err error) error {
-	// log the original error in very case
 	ec.Logger().Error(err)
 	// if it is a http client error, return the simplified error to user
-	var err2 errors2.HTTPClientError
+	var err2 hzerrors.HTTPClientError
 	if errors.As(err, &err2) {
 		return fmt.Errorf(err2.Text())
 	}

--- a/base/commands/viridian/common.go
+++ b/base/commands/viridian/common.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc/secrets"
-	hzerrors "github.com/hazelcast/hazelcast-commandline-client/errors"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/viridian"
 )
@@ -107,7 +106,7 @@ func matchClusterState(cluster viridian.Cluster, state string) (bool, error) {
 func handleErrorResponse(ec plug.ExecContext, err error) error {
 	ec.Logger().Error(err)
 	// if it is a http client error, return the simplified error to user
-	var err2 hzerrors.HTTPClientError
+	var err2 viridian.HTTPClientError
 	if errors.As(err, &err2) {
 		return fmt.Errorf(err2.Text())
 	}

--- a/base/commands/viridian/const.go
+++ b/base/commands/viridian/const.go
@@ -2,7 +2,6 @@ package viridian
 
 const (
 	flagName        = "name"
-	flagPlan        = "plan"
-	flagDevelopment = "development"
+	flagClusterType = "cluster-type"
 	flagOutputDir   = "output-dir"
 )

--- a/base/commands/viridian/const.go
+++ b/base/commands/viridian/const.go
@@ -1,7 +1,8 @@
 package viridian
 
 const (
-	flagName        = "name"
-	flagClusterType = "cluster-type"
-	flagOutputDir   = "output-dir"
+	flagName             = "name"
+	flagClusterType      = "cluster-type"
+	flagOutputDir        = "output-dir"
+	flagHazelcastVersion = "hazelcast-version"
 )

--- a/base/commands/viridian/custom_class_delete.go
+++ b/base/commands/viridian/custom_class_delete.go
@@ -2,7 +2,6 @@ package viridian
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
@@ -41,8 +40,7 @@ func (cmd CustomClassDeleteCmd) Exec(ctx context.Context, ec plug.ExecContext) e
 		return nil, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("deleting custom class. Did you login?: %w", err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	ec.PrintlnUnnecessary("Custom class deleted successfully.")

--- a/base/commands/viridian/custom_class_delete.go
+++ b/base/commands/viridian/custom_class_delete.go
@@ -4,8 +4,10 @@ import (
 	"context"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	"github.com/hazelcast/hazelcast-commandline-client/errors"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/prompt"
 )
 
 type CustomClassDeleteCmd struct{}
@@ -20,6 +22,7 @@ Make sure you login before running this command.
 	cc.SetCommandHelp(long, short)
 	cc.SetPositionalArgCount(2, 2)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
+	cc.AddBoolFlag(clc.FlagAutoYes, "", false, false, "skip confirming the delete operation")
 	return nil
 }
 
@@ -27,6 +30,18 @@ func (cmd CustomClassDeleteCmd) Exec(ctx context.Context, ec plug.ExecContext) e
 	api, err := getAPI(ec)
 	if err != nil {
 		return err
+	}
+	autoYes := ec.Props().GetBool(clc.FlagAutoYes)
+	if !autoYes {
+		p := prompt.New(ec.Stdin(), ec.Stdout())
+		yes, err := p.YesNo("Custom class will be deleted irreversibly, proceed?")
+		if err != nil {
+			ec.Logger().Info("User input could not be processed due to error: %s", err.Error())
+			return errors.ErrUserCancelled
+		}
+		if !yes {
+			return errors.ErrUserCancelled
+		}
 	}
 	// inputs
 	cluster := ec.Args()[0]

--- a/base/commands/viridian/custom_class_download.go
+++ b/base/commands/viridian/custom_class_download.go
@@ -2,7 +2,6 @@ package viridian
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	"github.com/hazelcast/hazelcast-commandline-client/errors"
@@ -68,8 +67,7 @@ func (cmd CustomClassDownloadCmd) Exec(ctx context.Context, ec plug.ExecContext)
 		return nil, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("downloading custom class. Did you login?: %w", err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	ec.PrintlnUnnecessary("Custom class downloaded successfully.")

--- a/base/commands/viridian/custom_class_list.go
+++ b/base/commands/viridian/custom_class_list.go
@@ -2,7 +2,6 @@ package viridian
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
@@ -43,8 +42,7 @@ func (cmd CustomClassListCmd) Exec(ctx context.Context, ec plug.ExecContext) err
 		return cs, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("getting custom classes. Did you login?: %w", err)
+		handleErrorResponse(ec, err)
 	}
 	stop()
 	cs := csi.([]viridian.CustomClass)

--- a/base/commands/viridian/custom_class_list.go
+++ b/base/commands/viridian/custom_class_list.go
@@ -42,7 +42,7 @@ func (cmd CustomClassListCmd) Exec(ctx context.Context, ec plug.ExecContext) err
 		return cs, nil
 	})
 	if err != nil {
-		handleErrorResponse(ec, err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	cs := csi.([]viridian.CustomClass)

--- a/base/commands/viridian/custom_class_upload.go
+++ b/base/commands/viridian/custom_class_upload.go
@@ -2,7 +2,6 @@ package viridian
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
@@ -40,8 +39,7 @@ func (cmd CustomClassUploadCmd) Exec(ctx context.Context, ec plug.ExecContext) e
 		return nil, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("uploading custom classes. Did you login?: %w", err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	ec.PrintlnUnnecessary("Custom class uploaded successfully.")

--- a/base/commands/viridian/download_logs.go
+++ b/base/commands/viridian/download_logs.go
@@ -3,7 +3,6 @@ package viridian
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
@@ -47,8 +46,7 @@ func (cm DownloadLogsCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 		return nil, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("error downloading cluster logs. Did you login?: %w", err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	return nil

--- a/base/commands/viridian/viridian_cluster_create.go
+++ b/base/commands/viridian/viridian_cluster_create.go
@@ -3,6 +3,7 @@ package viridian
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"

--- a/base/commands/viridian/viridian_cluster_create.go
+++ b/base/commands/viridian/viridian_cluster_create.go
@@ -27,7 +27,7 @@ Make sure you login before running this command.
 	cc.SetPositionalArgCount(0, 0)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
 	cc.AddStringFlag(flagName, "", "", false, "specify the cluster name; if not given an auto-generated name is used.")
-	cc.AddStringFlag(flagClusterType, "", "", false, "type for the cluster")
+	cc.AddStringFlag(flagClusterType, "", viridian.ClusterTypeServerless, false, "type for the cluster")
 	cc.AddStringFlag(flagHazelcastVersion, "", "", false, "version of the Hazelcast cluster")
 	return nil
 }

--- a/base/commands/viridian/viridian_cluster_create.go
+++ b/base/commands/viridian/viridian_cluster_create.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hazelcast/hazelcast-commandline-client/internal/viridian"
 )
 
+const defaultClusterType = "DEVMODE"
+
 type ClusterCreateCmd struct{}
 
 func (cm ClusterCreateCmd) Init(cc plug.InitContext) error {
@@ -27,7 +29,7 @@ Make sure you login before running this command.
 	cc.SetPositionalArgCount(0, 0)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
 	cc.AddStringFlag(flagName, "", "", false, "specify the cluster name; if not given an auto-generated name is used.")
-	cc.AddStringFlag(flagClusterType, "", "", false, "type for the cluster")
+	cc.AddStringFlag(flagClusterType, "", defaultClusterType, false, "type for the cluster")
 	return nil
 }
 

--- a/base/commands/viridian/viridian_cluster_create.go
+++ b/base/commands/viridian/viridian_cluster_create.go
@@ -14,8 +14,6 @@ import (
 	"github.com/hazelcast/hazelcast-commandline-client/internal/viridian"
 )
 
-const defaultClusterType = "DEVMODE"
-
 type ClusterCreateCmd struct{}
 
 func (cm ClusterCreateCmd) Init(cc plug.InitContext) error {
@@ -29,7 +27,8 @@ Make sure you login before running this command.
 	cc.SetPositionalArgCount(0, 0)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
 	cc.AddStringFlag(flagName, "", "", false, "specify the cluster name; if not given an auto-generated name is used.")
-	cc.AddStringFlag(flagClusterType, "", defaultClusterType, false, "type for the cluster")
+	cc.AddStringFlag(flagClusterType, "", "", false, "type for the cluster")
+	cc.AddStringFlag(flagHazelcastVersion, "", "", false, "version of the Hazelcast cluster")
 	return nil
 }
 
@@ -40,13 +39,14 @@ func (cm ClusterCreateCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 	}
 	name := ec.Props().GetString(flagName)
 	clusterType := ec.Props().GetString(flagClusterType)
+	hzVersion := ec.Props().GetString(flagHazelcastVersion)
 	csi, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
 		sp.SetText("Creating the cluster")
 		k8sCluster, err := getFirstAvailableK8sCluster(ctx, api)
 		if err != nil {
 			return nil, err
 		}
-		cs, err := api.CreateCluster(ctx, name, clusterType, k8sCluster.ID)
+		cs, err := api.CreateCluster(ctx, name, clusterType, k8sCluster.ID, hzVersion)
 		if err != nil {
 			return nil, err
 		}

--- a/base/commands/viridian/viridian_cluster_create.go
+++ b/base/commands/viridian/viridian_cluster_create.go
@@ -3,7 +3,6 @@ package viridian
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
@@ -56,8 +55,7 @@ func (cm ClusterCreateCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 		return cs, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("creating the cluster. Did you login?: %w", err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	cs := csi.(viridian.Cluster)

--- a/base/commands/viridian/viridian_cluster_delete.go
+++ b/base/commands/viridian/viridian_cluster_delete.go
@@ -2,7 +2,6 @@ package viridian
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	"github.com/hazelcast/hazelcast-commandline-client/errors"
@@ -54,8 +53,7 @@ func (cm ClusterDeleteCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 		return nil, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("error deleting the cluster. Did you login?: %w", err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	return nil

--- a/base/commands/viridian/viridian_cluster_get.go
+++ b/base/commands/viridian/viridian_cluster_get.go
@@ -2,7 +2,6 @@ package viridian
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
@@ -42,8 +41,7 @@ func (cm ClusterGetCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 		return c, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("retrieving the cluster. Did you login?: %w", err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	c := ci.(viridian.Cluster)

--- a/base/commands/viridian/viridian_cluster_list.go
+++ b/base/commands/viridian/viridian_cluster_list.go
@@ -2,7 +2,6 @@ package viridian
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
@@ -41,8 +40,7 @@ func (cm ClusterListCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 		return cs, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("error getting clusters. Did you login?: %w", err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	cs := csi.([]viridian.Cluster)

--- a/base/commands/viridian/viridian_cluster_resume.go
+++ b/base/commands/viridian/viridian_cluster_resume.go
@@ -2,7 +2,6 @@ package viridian
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
@@ -39,8 +38,7 @@ func (cm ClusterResumeCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 		return nil, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("error resuming the cluster. Did you login?: %w", err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	return nil

--- a/base/commands/viridian/viridian_cluster_stop.go
+++ b/base/commands/viridian/viridian_cluster_stop.go
@@ -12,7 +12,7 @@ import (
 type ClusterStopCmd struct{}
 
 func (cm ClusterStopCmd) Init(cc plug.InitContext) error {
-	cc.SetCommandUsage("stop-cluster [cluster-ID/name] [flags]")
+	cc.SetCommandUsage("pause-cluster [cluster-ID/name] [flags]")
 	long := `Stops the given Viridian cluster.
 
 Make sure you login before running this command.
@@ -47,5 +47,5 @@ func (cm ClusterStopCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 }
 
 func init() {
-	Must(plug.Registry.RegisterCommand("viridian:stop-cluster", &ClusterStopCmd{}))
+	Must(plug.Registry.RegisterCommand("viridian:pause-cluster", &ClusterStopCmd{}))
 }

--- a/base/commands/viridian/viridian_cluster_stop.go
+++ b/base/commands/viridian/viridian_cluster_stop.go
@@ -2,7 +2,6 @@ package viridian
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
@@ -39,8 +38,7 @@ func (cm ClusterStopCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 		return nil, nil
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return fmt.Errorf("stopping the cluster. Did you login?: %w", err)
+		return handleErrorResponse(ec, err)
 	}
 	stop()
 	return nil

--- a/base/commands/viridian/viridian_cluster_types.go
+++ b/base/commands/viridian/viridian_cluster_types.go
@@ -1,0 +1,71 @@
+package viridian
+
+import (
+	"context"
+
+	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/output"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/serialization"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/viridian"
+)
+
+type ClusterTypeListCmd struct{}
+
+func (ct ClusterTypeListCmd) Init(cc plug.InitContext) error {
+	cc.SetCommandUsage("list-cluster-types [flags]")
+	long := `Lists Viridian cluster types
+
+Make sure you login before running this command.
+`
+	short := "Lists Viridian cluster types"
+	cc.SetCommandHelp(long, short)
+	cc.SetPositionalArgCount(0, 0)
+	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
+	return nil
+}
+
+func (ct ClusterTypeListCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
+	api, err := getAPI(ec)
+	if err != nil {
+		return err
+	}
+	verbose := ec.Props().GetBool(clc.PropertyVerbose)
+	csi, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
+		sp.SetText("Retrieving cluster types")
+		cs, err := api.ListClusterTypes(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return cs, nil
+	})
+	if err != nil {
+		return handleErrorResponse(ec, err)
+	}
+	stop()
+	cs := csi.([]viridian.ClusterTypeItem)
+	var rows []output.Row
+	for _, c := range cs {
+		var r output.Row
+		if verbose {
+			r = append(r, output.Column{
+				Name:  "Cluster Type ID",
+				Type:  serialization.TypeInt64,
+				Value: c.ID,
+			})
+		}
+		r = append(r, output.Column{
+			Name:  "Name",
+			Type:  serialization.TypeString,
+			Value: c.Name,
+		})
+
+		rows = append(rows, r)
+	}
+	return ec.AddOutputRows(ctx, rows...)
+}
+
+func init() {
+	Must(plug.Registry.RegisterCommand("viridian:list-cluster-types", &ClusterTypeListCmd{}))
+}

--- a/base/commands/viridian/viridian_cluster_types.go
+++ b/base/commands/viridian/viridian_cluster_types.go
@@ -15,7 +15,7 @@ type ClusterTypeListCmd struct{}
 
 func (ct ClusterTypeListCmd) Init(cc plug.InitContext) error {
 	cc.SetCommandUsage("list-cluster-types [flags]")
-	long := `Lists available cluster type that can be used while creating a Viridian cluster.
+	long := `Lists available cluster types that can be used while creating a Viridian cluster.
 
 Make sure you login before running this command.
 `
@@ -50,7 +50,7 @@ func (ct ClusterTypeListCmd) Exec(ctx context.Context, ec plug.ExecContext) erro
 		var r output.Row
 		if verbose {
 			r = append(r, output.Column{
-				Name:  "Cluster Type ID",
+				Name:  "ID",
 				Type:  serialization.TypeInt64,
 				Value: c.ID,
 			})
@@ -60,7 +60,6 @@ func (ct ClusterTypeListCmd) Exec(ctx context.Context, ec plug.ExecContext) erro
 			Type:  serialization.TypeString,
 			Value: c.Name,
 		})
-
 		rows = append(rows, r)
 	}
 	return ec.AddOutputRows(ctx, rows...)

--- a/base/commands/viridian/viridian_cluster_types.go
+++ b/base/commands/viridian/viridian_cluster_types.go
@@ -34,11 +34,7 @@ func (ct ClusterTypeListCmd) Exec(ctx context.Context, ec plug.ExecContext) erro
 	verbose := ec.Props().GetBool(clc.PropertyVerbose)
 	csi, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
 		sp.SetText("Retrieving cluster types")
-		cs, err := api.ListClusterTypes(ctx)
-		if err != nil {
-			return nil, err
-		}
-		return cs, nil
+		return api.ListClusterTypes(ctx)
 	})
 	if err != nil {
 		return handleErrorResponse(ec, err)

--- a/base/commands/viridian/viridian_cluster_types.go
+++ b/base/commands/viridian/viridian_cluster_types.go
@@ -15,7 +15,7 @@ type ClusterTypeListCmd struct{}
 
 func (ct ClusterTypeListCmd) Init(cc plug.InitContext) error {
 	cc.SetCommandUsage("list-cluster-types [flags]")
-	long := `Lists Viridian cluster types
+	long := `Lists available cluster type that can be used while creating a Viridian cluster.
 
 Make sure you login before running this command.
 `
@@ -44,7 +44,7 @@ func (ct ClusterTypeListCmd) Exec(ctx context.Context, ec plug.ExecContext) erro
 		return handleErrorResponse(ec, err)
 	}
 	stop()
-	cs := csi.([]viridian.ClusterTypeItem)
+	cs := csi.([]viridian.ClusterType)
 	var rows []output.Row
 	for _, c := range cs {
 		var r output.Row

--- a/base/commands/viridian/viridian_import_config.go
+++ b/base/commands/viridian/viridian_import_config.go
@@ -1,0 +1,63 @@
+package viridian
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	"github.com/hazelcast/hazelcast-commandline-client/clc/config"
+	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
+)
+
+type ImportConfigCmd struct{}
+
+func (cmd ImportConfigCmd) Init(cc plug.InitContext) error {
+	cc.SetCommandUsage("import-config [cluster-name/cluster-ID] [flags]")
+	long := `Imports config of the given Viridian cluster.
+
+Make sure you login before running this command.
+`
+	short := "Imports config of the given Viridian cluster."
+	cc.SetCommandHelp(long, short)
+	cc.SetPositionalArgCount(1, 1)
+	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
+	return nil
+}
+
+func (cmd ImportConfigCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
+	api, err := getAPI(ec)
+	if err != nil {
+		return err
+	}
+	clusterNameOrID := ec.Args()[0]
+	cluster, err := api.FindCluster(ctx, clusterNameOrID)
+	cfgName := cluster.Name
+	if err != nil {
+		return handleErrorResponse(ec, err)
+	}
+	cp, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
+		sp.SetText("Importing configuration")
+		zipPath, stop, err := api.DownloadConfig(ctx, cluster.ID)
+		if err != nil {
+			return nil, err
+		}
+		defer stop()
+		cfgPath, err := config.CreateFromZip(ctx, ec, cfgName, zipPath)
+		if err != nil {
+			return nil, err
+		}
+		return cfgPath, nil
+	})
+	if err != nil {
+		return handleErrorResponse(ec, err)
+	}
+	stop()
+	ec.Logger().Info("Imported configuration %s and saved to: %s", cfgName, cp)
+	ec.PrintlnUnnecessary(fmt.Sprintf("Imported configuration: %s", cfgName))
+	return nil
+}
+
+func init() {
+	Must(plug.Registry.RegisterCommand("viridian:import-config", &ImportConfigCmd{}))
+}

--- a/base/commands/viridian/viridian_import_config.go
+++ b/base/commands/viridian/viridian_import_config.go
@@ -14,14 +14,15 @@ type ImportConfigCmd struct{}
 
 func (cmd ImportConfigCmd) Init(cc plug.InitContext) error {
 	cc.SetCommandUsage("import-config [cluster-name/cluster-ID] [flags]")
-	long := `Imports config of the given Viridian cluster.
+	long := `Imports connection configuration of the given Viridian cluster.
 
 Make sure you login before running this command.
 `
-	short := "Imports config of the given Viridian cluster."
+	short := "Imports connection configuration of the given Viridian cluster."
 	cc.SetCommandHelp(long, short)
 	cc.SetPositionalArgCount(1, 1)
 	cc.AddStringFlag(propAPIKey, "", "", false, "Viridian API Key")
+	cc.AddStringFlag(flagName, "", "", false, "name of the connection configuration")
 	return nil
 }
 
@@ -32,9 +33,12 @@ func (cmd ImportConfigCmd) Exec(ctx context.Context, ec plug.ExecContext) error 
 	}
 	clusterNameOrID := ec.Args()[0]
 	cluster, err := api.FindCluster(ctx, clusterNameOrID)
-	cfgName := cluster.Name
 	if err != nil {
 		return handleErrorResponse(ec, err)
+	}
+	cfgName := ec.Props().GetString(flagName)
+	if cfgName == "" {
+		cfgName = cluster.Name
 	}
 	cp, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
 		sp.SetText("Importing configuration")

--- a/base/commands/viridian/viridian_it_test.go
+++ b/base/commands/viridian/viridian_it_test.go
@@ -162,7 +162,7 @@ func createCluster_InteractiveTest(t *testing.T) {
 func stopCluster_NonInteractiveTest(t *testing.T) {
 	viridianTester(t, func(ctx context.Context, tcx it.TestContext) {
 		c := createOrGetClusterWithState(ctx, tcx, "RUNNING")
-		tcx.CLCExecute(ctx, "viridian", "stop-cluster", c.ID)
+		tcx.CLCExecute(ctx, "viridian", "pause-cluster", c.ID)
 		tcx.AssertStderrContains("OK")
 		check.Must(waitState(ctx, tcx, c.ID, "STOPPED"))
 	})
@@ -173,7 +173,7 @@ func stopCluster_InteractiveTest(t *testing.T) {
 		tcx.WithShell(ctx, func(tcx it.TestContext) {
 			tcx.WithReset(func() {
 				c := createOrGetClusterWithState(ctx, tcx, "RUNNING")
-				tcx.WriteStdinf("\\viridian stop-cluster %s\n", c.Name)
+				tcx.WriteStdinf("\\viridian pause-cluster %s\n", c.Name)
 				tcx.AssertStderrContains("OK")
 				check.Must(waitState(ctx, tcx, c.ID, "STOPPED"))
 			})

--- a/base/commands/viridian/viridian_login.go
+++ b/base/commands/viridian/viridian_login.go
@@ -69,8 +69,7 @@ func (cm LoginCmd) retrieveToken(ctx context.Context, ec plug.ExecContext, key, 
 		return api.Token(), err
 	})
 	if err != nil {
-		ec.Logger().Error(err)
-		return "", errors.New("login failed")
+		return "", handleErrorResponse(ec, err)
 	}
 	stop()
 	return ti.(string), nil

--- a/docs/modules/ROOT/pages/clc-viridian.adoc
+++ b/docs/modules/ROOT/pages/clc-viridian.adoc
@@ -122,8 +122,6 @@ Parameters:
 |`--cluster-type`
 |Optional
 |Sets the cluster-type for the created cluster.
-
-WARNING: You can set `DEVMODE` to `SERVERLESS` without giving the `--hazelcast-version`. However, if you set `--cluster-type` to `DEVMODE` without providing `--hazelcast-version`, it will be automatically converted to `SERVERLESS`.
 |
 
 |`--hazelcast-version`

--- a/docs/modules/ROOT/pages/clc-viridian.adoc
+++ b/docs/modules/ROOT/pages/clc-viridian.adoc
@@ -14,6 +14,7 @@ clc viridian [command] [options]
 == Commands
 
 * <<clc-viridian-login, clc viridian login>>
+* <<clc-viridian-list-cluster-types, clc viridian list-cluster-types>>
 * <<clc-viridian-create-cluster, clc viridian create-cluster>>
 * <<clc-viridian-get-cluster, clc viridian get-cluster>>
 * <<clc-viridian-list-clusters, clc viridian list-clusters>>
@@ -21,6 +22,7 @@ clc viridian [command] [options]
 * <<clc-viridian-resume-cluster, clc viridian resume-cluster>>
 * <<clc-viridian-delete-cluster, clc viridian delete-cluster>>
 * <<clc-viridian-download-logs, clc viridian download-logs>>
+* <<clc-viridian-import-config, clc viridian import-config>>
 * <<clc-viridian-list-custom-classes, clc viridian list-custom-classes>>
 * <<clc-viridian-upload-custom-class, clc viridian upload-custom-class>>
 * <<clc-viridian-download-custom-class, clc viridian download-custom-class>>
@@ -62,6 +64,32 @@ Parameters:
 
 |===
 
+== clc viridian list-cluster-types
+
+Lists available cluster type that can be used while creating a Viridian cluster.
+
+Make sure you login before running this command.
+
+Usage:
+
+[source,bash]
+----
+clc viridian list-cluster-types [flags]
+----
+
+Parameters:
+
+[cols="1m,1a,2a,1a"]
+|===
+|Parameter|Required|Description|Default
+
+|`--api-key`
+|Optional
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|
+
+|===
+
 == clc viridian create-cluster
 
 Creates a Viridian cluster.
@@ -91,15 +119,10 @@ Parameters:
 |Sets the name of the created cluster. If not given, an auto-generated name will be used.
 |
 
-|`--plan`
+|`--cluster-type`
 |Optional
-|Sets the plan for the created cluster.
+|Sets the cluster-type for the created cluster.
 |serverless
-
-|`--development`
-|Optional
-|Creates a development cluster.
-|false
 |===
 
 == clc viridian get-cluster
@@ -268,6 +291,30 @@ Parameters:
 
 |===
 
+== clc viridian import-config
+
+Imports config of the given Viridian cluster.
+
+Make sure you login before running this command.
+
+Usage:
+
+[source,bash]
+----
+clc import-config [cluster-name/cluster-ID] [flags]
+----
+
+Parameters:
+
+[cols="1m,1a,2a,1a"]
+|===
+|Parameter|Required|Description|Default
+
+|`--api-key`
+|Optional
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|
+|===
 
 
 == clc viridian list-custom-classes

--- a/docs/modules/ROOT/pages/clc-viridian.adoc
+++ b/docs/modules/ROOT/pages/clc-viridian.adoc
@@ -122,7 +122,14 @@ Parameters:
 |`--cluster-type`
 |Optional
 |Sets the cluster-type for the created cluster.
-|serverless
+
+WARNING: You can set `DEVMODE` to `SERVERLESS` without giving the `--hazelcast-version`. However, if you set `--cluster-type` to `DEVMODE` without providing `--hazelcast-version`, it will be automatically converted to `SERVERLESS`.
+|
+
+|`--hazelcast-version`
+|Optional
+|Sets the version of the Hazelcast cluster to be created.
+|
 |===
 
 == clc viridian get-cluster

--- a/docs/modules/ROOT/pages/clc-viridian.adoc
+++ b/docs/modules/ROOT/pages/clc-viridian.adoc
@@ -15,7 +15,7 @@ clc viridian [command] [options]
 * <<clc-viridian-create-cluster, clc viridian create-cluster>>
 * <<clc-viridian-get-cluster, clc viridian get-cluster>>
 * <<clc-viridian-list-clusters, clc viridian list-clusters>>
-* <<clc-viridian-stop-cluster, clc viridian stop-cluster>>
+* <<clc-viridian-stop-cluster, clc viridian pause-cluster>>
 * <<clc-viridian-resume-cluster, clc viridian resume-cluster>>
 * <<clc-viridian-delete-cluster, clc viridian delete-cluster>>
 * <<clc-viridian-download-logs, clc viridian download-logs>>
@@ -152,7 +152,7 @@ Parameters:
 
 |===
 
-== clc viridian stop-cluster
+== clc viridian pause-cluster
 
 Stops the given Viridian cluster.
 
@@ -162,7 +162,7 @@ Usage:
 
 [source,bash]
 ----
-clc viridian stop-cluster [cluster-ID/name] [flags]
+clc viridian pause-cluster [cluster-ID/name] [flags]
 ----
 
 Parameters:

--- a/docs/modules/ROOT/pages/clc-viridian.adoc
+++ b/docs/modules/ROOT/pages/clc-viridian.adoc
@@ -15,7 +15,7 @@ clc viridian [command] [options]
 * <<clc-viridian-create-cluster, clc viridian create-cluster>>
 * <<clc-viridian-get-cluster, clc viridian get-cluster>>
 * <<clc-viridian-list-clusters, clc viridian list-clusters>>
-* <<clc-viridian-stop-cluster, clc viridian pause-cluster>>
+* <<clc-viridian-pause-cluster, clc viridian pause-cluster>>
 * <<clc-viridian-resume-cluster, clc viridian resume-cluster>>
 * <<clc-viridian-delete-cluster, clc viridian delete-cluster>>
 * <<clc-viridian-download-logs, clc viridian download-logs>>

--- a/docs/modules/ROOT/pages/clc-viridian.adoc
+++ b/docs/modules/ROOT/pages/clc-viridian.adoc
@@ -66,7 +66,7 @@ Parameters:
 
 == clc viridian list-cluster-types
 
-Lists available cluster type that can be used while creating a Viridian cluster.
+Lists available cluster types that can be used while creating a Viridian cluster.
 
 Make sure you login before running this command.
 
@@ -85,7 +85,7 @@ Parameters:
 
 |`--api-key`
 |Optional
-|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing API keys will be used.
 |
 
 |===
@@ -111,7 +111,7 @@ Parameters:
 
 |`--api-key`
 |Optional
-|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing API keys will be used.
 |
 
 |`--name`
@@ -146,7 +146,7 @@ Parameters:
 
 |`--api-key`
 |Optional
-|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing API keys will be used.
 |
 
 |===
@@ -172,7 +172,7 @@ Parameters:
 
 |`--api-key`
 |Optional
-|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing API keys will be used.
 |
 
 |===
@@ -198,7 +198,7 @@ Parameters:
 
 |`--api-key`
 |Optional
-|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing API keys will be used.
 |
 
 |===
@@ -224,7 +224,7 @@ Parameters:
 
 |`--api-key`
 |Optional
-|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing API keys will be used.
 |
 
 |===
@@ -250,7 +250,7 @@ Parameters:
 
 |`--api-key`
 |Optional
-|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing API keys will be used.
 |
 
 |`--yes`
@@ -281,7 +281,7 @@ Parameters:
 
 |`--api-key`
 |Optional
-|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing API keys will be used.
 |
 
 |`--output-dir` `-o`
@@ -293,7 +293,7 @@ Parameters:
 
 == clc viridian import-config
 
-Imports config of the given Viridian cluster.
+Imports connection configuration of the given Viridian cluster.
 
 Make sure you login before running this command.
 
@@ -312,7 +312,7 @@ Parameters:
 
 |`--api-key`
 |Optional
-|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing api keys will be used.
+|Sets the API key. Overrides the `CLC_VIRIDIAN_API_KEY` environment variable. If not given, one of the existing API keys will be used.
 |
 |===
 

--- a/docs/modules/ROOT/pages/managing-viridian-clusters.adoc
+++ b/docs/modules/ROOT/pages/managing-viridian-clusters.adoc
@@ -1,6 +1,6 @@
 == Managing Viridian Clusters Using the Hazelcast CLC
 
-:description: In this tutorial, you'll learn the basics of managing Viridian clusters using CLC. You'll see how to create, list, delete clusters and how to download their logs. Also, you'll learn how to perform stop/resume operations on Viridian clusters using CLC.
+:description: In this tutorial, you'll learn the basics of managing Viridian clusters using CLC. You'll see how to create, list, delete clusters and how to download their logs. Also, you'll learn how to perform pause/resume operations on Viridian clusters using CLC.
 
 {description}
 
@@ -82,12 +82,12 @@ OK
 This command downloads the logs to the current working directory.
 By using the `--output-dir` flag, you can download the logs to the given directory of your choice.
 
-== Stop/Resume a Cluster on Viridian
+== Pause/Resume a Cluster on Viridian
 
-You can stop a running cluster by using its name or ID by executing the command below. See link:https://docs.hazelcast.com/cloud/stop-and-resume[Pausing and Resuming Clusters] documentation for more information.
+You can pause a running cluster by using its name or ID by executing the command below. See link:https://docs.hazelcast.com/cloud/stop-and-resume[Pausing and Resuming Clusters] documentation for more information.
 [source, bash]
 ----
-clc viridian stop-cluster my-cluster
+clc viridian pause-cluster my-cluster
 OK
 ----
 When you want to resume it, you can execute the following command by using its name or ID:

--- a/docs/modules/ROOT/pages/managing-viridian-clusters.adoc
+++ b/docs/modules/ROOT/pages/managing-viridian-clusters.adoc
@@ -31,13 +31,11 @@ To create a new cluster on Viridian, you can use the following command:
 
 [source, bash]
 ----
-clc viridian create-cluster --name my-cluster --cluster-type DEVMODE --hazelcast-version 5.3.0-BETA-2
+clc viridian create-cluster --name my-cluster
 Imported configuration: my-cluster
 OK
 ----
 This command creates a development cluster named `my-cluster`.
-
-WARNING: You can set `DEVMODE` to `SERVERLESS` without giving the `--hazelcast-version`. However, if you set `--cluster-type` to `DEVMODE` without providing `--hazelcast-version`, it will be automatically converted to `SERVERLESS`.
 
 == Listing Clusters on Viridian
 

--- a/docs/modules/ROOT/pages/managing-viridian-clusters.adoc
+++ b/docs/modules/ROOT/pages/managing-viridian-clusters.adoc
@@ -31,11 +31,13 @@ To create a new cluster on Viridian, you can use the following command:
 
 [source, bash]
 ----
-clc viridian create-cluster --name my-cluster --development
+clc viridian create-cluster --name my-cluster --cluster-type DEVMODE --hazelcast-version 5.3.0-BETA-2
 Imported configuration: my-cluster
 OK
 ----
 This command creates a development cluster named `my-cluster`.
+
+WARNING: You can set `DEVMODE` to `SERVERLESS` without giving the `--hazelcast-version`. However, if you set `--cluster-type` to `DEVMODE` without providing `--hazelcast-version`, it will be automatically converted to `SERVERLESS`.
 
 == Listing Clusters on Viridian
 

--- a/errors/error.go
+++ b/errors/error.go
@@ -56,16 +56,18 @@ func NewHTTPClientError(code int, body []byte) error {
 	err := HTTPClientError{
 		code:    code,
 		rawResp: string(body),
-		text:    "an unexpected error occurred, please check logs for details", // it can be overwritten
+		// it can be overwritten
+		text: "an unexpected error occurred, please check logs for details",
 	}
 	type ErrResp struct {
 		Message string `json:"message"`
 	}
-	var errResp ErrResp
-	json.Unmarshal(body, &errResp) // if there is an error, errResp.Message will be empty, so we can ignore it
+	var resp ErrResp
+	// if there is an error, resp.Message will be empty, so we can ignore it
+	json.Unmarshal(body, &resp)
 	// overwriting error text
-	if errResp.Message != "" {
-		err.text = errResp.Message
+	if resp.Message != "" {
+		err.text = resp.Message
 	}
 	return err
 }

--- a/errors/error.go
+++ b/errors/error.go
@@ -17,9 +17,7 @@
 package errors
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 )
 
 var (
@@ -44,42 +42,4 @@ func (w WrappedError) Error() string {
 type HTTPError interface {
 	Text() string
 	Code() int
-}
-
-type HTTPClientError struct {
-	code    int
-	text    string
-	rawResp string
-}
-
-func NewHTTPClientError(code int, body []byte) error {
-	err := HTTPClientError{
-		code:    code,
-		rawResp: string(body),
-		// it can be overwritten
-		text: "an unexpected error occurred, please check logs for details",
-	}
-	type ErrResp struct {
-		Message string `json:"message"`
-	}
-	var resp ErrResp
-	// if there is an error, resp.Message will be empty, so we can ignore it
-	json.Unmarshal(body, &resp)
-	// overwriting error text
-	if resp.Message != "" {
-		err.text = resp.Message
-	}
-	return err
-}
-
-func (h HTTPClientError) Error() string {
-	return fmt.Sprintf("%d: %s", h.code, h.rawResp)
-}
-
-func (h HTTPClientError) Text() string {
-	return h.text
-}
-
-func (h HTTPClientError) Code() int {
-	return h.code
 }

--- a/internal/viridian/api.go
+++ b/internal/viridian/api.go
@@ -127,6 +127,21 @@ func (a API) FindCluster(ctx context.Context, idOrName string) (Cluster, error) 
 	return Cluster{}, fmt.Errorf("no such cluster found: %s", idOrName)
 }
 
+func (a API) FindClusterType(ctx context.Context, name string) (ClusterType, error) {
+	clusterTypes, err := a.ListClusterTypes(ctx)
+	if err != nil {
+		return ClusterType{}, err
+	}
+	var found ClusterType
+	for _, ct := range clusterTypes {
+		if strings.ToLower(ct.Name) == strings.ToLower(name) {
+			found = ct
+			break
+		}
+	}
+	return found, nil
+}
+
 func (a API) findArtifactIDAndName(ctx context.Context, clusterName, artifact string) (int64, string, error) {
 	customClasses, err := a.ListCustomClasses(ctx, clusterName)
 	if err != nil {

--- a/internal/viridian/api.go
+++ b/internal/viridian/api.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/hazelcast/hazelcast-commandline-client/errors"
 )
 
 const (
@@ -175,7 +177,7 @@ func doGet[Res any](ctx context.Context, path, token string) (res Res, err error
 		}
 		return res, nil
 	}
-	return res, fmt.Errorf("%d: %s", rawRes.StatusCode, string(rb))
+	return res, errors.NewHTTPClientError(rawRes.StatusCode, rb)
 }
 
 func doPost[Req, Res any](ctx context.Context, path, token string, request Req) (res Res, err error) {
@@ -215,7 +217,7 @@ func doPostBytes(ctx context.Context, url, token string, body []byte) ([]byte, e
 	if res.StatusCode == 200 {
 		return rb, nil
 	}
-	return nil, fmt.Errorf("%d: %s", res.StatusCode, string(rb))
+	return nil, errors.NewHTTPClientError(res.StatusCode, rb)
 }
 
 func doDelete(ctx context.Context, path, token string) error {
@@ -238,7 +240,7 @@ func doDelete(ctx context.Context, path, token string) error {
 		return fmt.Errorf("reading response: %w", err)
 	}
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("%d: %s", res.StatusCode, string(rb))
+		return errors.NewHTTPClientError(res.StatusCode, rb)
 	}
 	return nil
 }

--- a/internal/viridian/api.go
+++ b/internal/viridian/api.go
@@ -132,14 +132,12 @@ func (a API) FindClusterType(ctx context.Context, name string) (ClusterType, err
 	if err != nil {
 		return ClusterType{}, err
 	}
-	var found ClusterType
 	for _, ct := range clusterTypes {
-		if strings.ToLower(ct.Name) == strings.ToLower(name) {
-			found = ct
-			break
+		if strings.ToUpper(ct.Name) == strings.ToUpper(name) {
+			return ct, nil
 		}
 	}
-	return found, nil
+	return ClusterType{}, nil
 }
 
 func (a API) findArtifactIDAndName(ctx context.Context, clusterName, artifact string) (int64, string, error) {

--- a/internal/viridian/api.go
+++ b/internal/viridian/api.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
-	"github.com/hazelcast/hazelcast-commandline-client/errors"
 )
 
 const (
@@ -128,11 +126,11 @@ func (a API) FindCluster(ctx context.Context, idOrName string) (Cluster, error) 
 }
 
 func (a API) FindClusterType(ctx context.Context, name string) (ClusterType, error) {
-	clusterTypes, err := a.ListClusterTypes(ctx)
+	cts, err := a.ListClusterTypes(ctx)
 	if err != nil {
 		return ClusterType{}, err
 	}
-	for _, ct := range clusterTypes {
+	for _, ct := range cts {
 		if strings.ToUpper(ct.Name) == strings.ToUpper(name) {
 			return ct, nil
 		}
@@ -195,7 +193,7 @@ func doGet[Res any](ctx context.Context, path, token string) (res Res, err error
 		}
 		return res, nil
 	}
-	return res, errors.NewHTTPClientError(rawRes.StatusCode, rb)
+	return res, NewHTTPClientError(rawRes.StatusCode, rb)
 }
 
 func doPost[Req, Res any](ctx context.Context, path, token string, request Req) (res Res, err error) {
@@ -235,7 +233,7 @@ func doPostBytes(ctx context.Context, url, token string, body []byte) ([]byte, e
 	if res.StatusCode == 200 {
 		return rb, nil
 	}
-	return nil, errors.NewHTTPClientError(res.StatusCode, rb)
+	return nil, NewHTTPClientError(res.StatusCode, rb)
 }
 
 func doDelete(ctx context.Context, path, token string) error {
@@ -258,7 +256,7 @@ func doDelete(ctx context.Context, path, token string) error {
 		return fmt.Errorf("reading response: %w", err)
 	}
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
-		return errors.NewHTTPClientError(res.StatusCode, rb)
+		return NewHTTPClientError(res.StatusCode, rb)
 	}
 	return nil
 }

--- a/internal/viridian/cluster.go
+++ b/internal/viridian/cluster.go
@@ -115,3 +115,16 @@ func (a API) GetCluster(ctx context.Context, idOrName string) (Cluster, error) {
 	}
 	return c, nil
 }
+
+type ClusterTypeItem struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+func (a API) ListClusterTypes(ctx context.Context) ([]ClusterTypeItem, error) {
+	csw, err := doGet[Wrapper[[]ClusterTypeItem]](ctx, "/cluster_types", a.Token())
+	if err != nil {
+		return nil, fmt.Errorf("listing cluster types: %w", err)
+	}
+	return csw.Content, nil
+}

--- a/internal/viridian/cluster.go
+++ b/internal/viridian/cluster.go
@@ -7,8 +7,12 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"strings"
 	"time"
 )
+
+const ClusterTypeDevMode = "DEVMODE"
+const ClusterTypeServerless = "SERVERLESS"
 
 type createClusterRequest struct {
 	KubernetesClusterID int    `json:"kubernetesClusterId"`
@@ -19,7 +23,7 @@ type createClusterRequest struct {
 
 type createClusterResponse Cluster
 
-func (a API) CreateCluster(ctx context.Context, name string, clusterType string, k8sClusterID int) (Cluster, error) {
+func (a API) CreateCluster(ctx context.Context, name string, clusterType string, k8sClusterID int, hzVersion string) (Cluster, error) {
 	if name == "" {
 		name = clusterName()
 	}
@@ -29,6 +33,9 @@ func (a API) CreateCluster(ctx context.Context, name string, clusterType string,
 	}
 	clusterTypeID := cType.ID
 	planName := cType.Name
+	if strings.ToUpper(cType.Name) == ClusterTypeDevMode && hzVersion == "" {
+		planName = ClusterTypeServerless
+	}
 	c := createClusterRequest{
 		KubernetesClusterID: k8sClusterID,
 		Name:                name,

--- a/internal/viridian/cluster.go
+++ b/internal/viridian/cluster.go
@@ -55,11 +55,11 @@ func clusterName() string {
 }
 
 func (a API) StopCluster(ctx context.Context, idOrName string) error {
-	cid, err := a.findClusterID(ctx, idOrName)
+	c, err := a.FindCluster(ctx, idOrName)
 	if err != nil {
 		return err
 	}
-	ok, err := doPost[[]byte, bool](ctx, fmt.Sprintf("/cluster/%s/stop", cid), a.Token(), nil)
+	ok, err := doPost[[]byte, bool](ctx, fmt.Sprintf("/cluster/%s/stop", c.ID), a.Token(), nil)
 	if err != nil {
 		return fmt.Errorf("stopping cluster: %w", err)
 	}
@@ -78,11 +78,11 @@ func (a API) ListClusters(ctx context.Context) ([]Cluster, error) {
 }
 
 func (a API) ResumeCluster(ctx context.Context, idOrName string) error {
-	cid, err := a.findClusterID(ctx, idOrName)
+	c, err := a.FindCluster(ctx, idOrName)
 	if err != nil {
 		return err
 	}
-	ok, err := doPost[[]byte, bool](ctx, fmt.Sprintf("/cluster/%s/resume", cid), a.Token(), nil)
+	ok, err := doPost[[]byte, bool](ctx, fmt.Sprintf("/cluster/%s/resume", c.ID), a.Token(), nil)
 	if err != nil {
 		return fmt.Errorf("resuming cluster: %w", err)
 	}
@@ -93,11 +93,11 @@ func (a API) ResumeCluster(ctx context.Context, idOrName string) error {
 }
 
 func (a API) DeleteCluster(ctx context.Context, idOrName string) error {
-	cid, err := a.findClusterID(ctx, idOrName)
+	c, err := a.FindCluster(ctx, idOrName)
 	if err != nil {
 		return err
 	}
-	err = doDelete(ctx, fmt.Sprintf("/cluster/%s", cid), a.Token())
+	err = doDelete(ctx, fmt.Sprintf("/cluster/%s", c.ID), a.Token())
 	if err != nil {
 		return fmt.Errorf("deleting cluster: %w", err)
 	}
@@ -105,11 +105,11 @@ func (a API) DeleteCluster(ctx context.Context, idOrName string) error {
 }
 
 func (a API) GetCluster(ctx context.Context, idOrName string) (Cluster, error) {
-	cid, err := a.findClusterID(ctx, idOrName)
+	cluster, err := a.FindCluster(ctx, idOrName)
 	if err != nil {
 		return Cluster{}, err
 	}
-	c, err := doGet[Cluster](ctx, fmt.Sprintf("/cluster/%s", cid), a.Token())
+	c, err := doGet[Cluster](ctx, fmt.Sprintf("/cluster/%s", cluster.ID), a.Token())
 	if err != nil {
 		return Cluster{}, fmt.Errorf("retrieving cluster: %w", err)
 	}

--- a/internal/viridian/cluster.go
+++ b/internal/viridian/cluster.go
@@ -7,7 +7,6 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"strings"
 	"time"
 )
 
@@ -20,8 +19,6 @@ type createClusterRequest struct {
 
 type createClusterResponse Cluster
 
-const defaultClusterType = "devmode"
-
 func (a API) CreateCluster(ctx context.Context, name string, clusterType string, k8sClusterID int) (Cluster, error) {
 	if name == "" {
 		name = clusterName()
@@ -32,19 +29,6 @@ func (a API) CreateCluster(ctx context.Context, name string, clusterType string,
 	}
 	clusterTypeID := cType.ID
 	planName := cType.Name
-	if cType.Name == "" {
-		clusterTypes, err := a.ListClusterTypes(ctx)
-		if err != nil {
-			return Cluster{}, err
-		}
-		for _, ct := range clusterTypes {
-			if strings.ToLower(ct.Name) == defaultClusterType {
-				clusterTypeID = ct.ID
-				planName = ct.Name
-				break
-			}
-		}
-	}
 	c := createClusterRequest{
 		KubernetesClusterID: k8sClusterID,
 		Name:                name,

--- a/internal/viridian/cluster_log.go
+++ b/internal/viridian/cluster_log.go
@@ -12,11 +12,11 @@ import (
 )
 
 func (a API) DownloadClusterLogs(ctx context.Context, destDir string, idOrName string) error {
-	cid, err := a.findClusterID(ctx, idOrName)
+	c, err := a.FindCluster(ctx, idOrName)
 	if err != nil {
 		return err
 	}
-	zipPath, stop, err := download(ctx, makeUrl(fmt.Sprintf("/cluster/%s/logs", cid)), a.token)
+	zipPath, stop, err := download(ctx, makeUrl(fmt.Sprintf("/cluster/%s/logs", c.ID)), a.token)
 	if err != nil {
 		return err
 	}

--- a/internal/viridian/custom_class_download.go
+++ b/internal/viridian/custom_class_download.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc/paths"
-	"github.com/hazelcast/hazelcast-commandline-client/errors"
 )
 
 type DownloadProgressPrinter struct {
@@ -55,7 +54,7 @@ func doCustomClassDownload(ctx context.Context, progressSetter func(progress flo
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return errors.NewHTTPClientError(res.StatusCode, nil)
+		return NewHTTPClientError(res.StatusCode, nil)
 	}
 	if err != nil {
 		return fmt.Errorf("downloading custom class: %w", err)

--- a/internal/viridian/custom_class_download.go
+++ b/internal/viridian/custom_class_download.go
@@ -58,7 +58,7 @@ func doCustomClassDownload(ctx context.Context, progressSetter func(progress flo
 		return errors.NewHTTPClientError(res.StatusCode, nil)
 	}
 	if err != nil {
-		return errors.NewHTTPClientError(res.StatusCode, nil)
+		return fmt.Errorf("downloading custom class: %w", err)
 	}
 	p := &DownloadProgressPrinter{SetterFunc: progressSetter, Total: uint64(res.ContentLength)}
 	_, err = io.Copy(f, io.TeeReader(res.Body, p))

--- a/internal/viridian/custom_class_download.go
+++ b/internal/viridian/custom_class_download.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc/paths"
+	"github.com/hazelcast/hazelcast-commandline-client/errors"
 )
 
 type DownloadProgressPrinter struct {
@@ -54,10 +55,10 @@ func doCustomClassDownload(ctx context.Context, progressSetter func(progress flo
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("downloading custom class: %w", err)
+		return errors.NewHTTPClientError(res.StatusCode, nil)
 	}
 	if err != nil {
-		return fmt.Errorf("downloading custom class: %w", err)
+		return errors.NewHTTPClientError(res.StatusCode, nil)
 	}
 	p := &DownloadProgressPrinter{SetterFunc: progressSetter, Total: uint64(res.ContentLength)}
 	_, err = io.Copy(f, io.TeeReader(res.Body, p))

--- a/internal/viridian/custom_class_upload.go
+++ b/internal/viridian/custom_class_upload.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-
-	"github.com/hazelcast/hazelcast-commandline-client/errors"
 )
 
 type UploadProgressReader struct {
@@ -76,7 +74,7 @@ func doCustomClassUpload(ctx context.Context, progressSetter func(progress float
 	}
 	res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return errors.NewHTTPClientError(res.StatusCode, resBody.Bytes())
+		return NewHTTPClientError(res.StatusCode, resBody.Bytes())
 	}
 	return nil
 }

--- a/internal/viridian/custom_class_upload.go
+++ b/internal/viridian/custom_class_upload.go
@@ -3,13 +3,14 @@ package viridian
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
-	"log"
+
 	"mime/multipart"
 	"net/http"
 	"os"
 	"path/filepath"
+
+	"github.com/hazelcast/hazelcast-commandline-client/errors"
 )
 
 type UploadProgressReader struct {
@@ -71,11 +72,11 @@ func doCustomClassUpload(ctx context.Context, progressSetter func(progress float
 	resBody := &bytes.Buffer{}
 	_, err = resBody.ReadFrom(res.Body)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("%d: %s", res.StatusCode, resBody.String())
+		return errors.NewHTTPClientError(res.StatusCode, resBody.Bytes())
 	}
 	return nil
 }

--- a/internal/viridian/errors.go
+++ b/internal/viridian/errors.go
@@ -1,0 +1,45 @@
+package viridian
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type HTTPClientError struct {
+	code    int
+	text    string
+	rawResp string
+}
+
+type ErrResponse struct {
+	Message string `json:"message"`
+}
+
+func NewHTTPClientError(code int, body []byte) error {
+	err := HTTPClientError{
+		code:    code,
+		rawResp: string(body),
+		// it can be overwritten
+		text: "an unexpected error occurred, please check logs for details",
+	}
+	var resp ErrResponse
+	// if there is an error, resp.Message will be empty, so we can ignore it
+	json.Unmarshal(body, &resp)
+	// overwriting error text
+	if resp.Message != "" {
+		err.text = resp.Message
+	}
+	return err
+}
+
+func (h HTTPClientError) Error() string {
+	return fmt.Sprintf("%d: %s", h.code, h.rawResp)
+}
+
+func (h HTTPClientError) Text() string {
+	return h.text
+}
+
+func (h HTTPClientError) Code() int {
+	return h.code
+}

--- a/internal/viridian/types.go
+++ b/internal/viridian/types.go
@@ -18,16 +18,3 @@ type CustomClass struct {
 type K8sCluster struct {
 	ID int `json:"id"`
 }
-
-type ClusterType int
-
-const (
-	ClusterTypeDev  ClusterType = 6
-	ClusterTypeProd ClusterType = 5
-)
-
-type ClusterPlan string
-
-const (
-	ClusterPlanServerless ClusterPlan = "SERVERLESS"
-)


### PR DESCRIPTION
- Remove the `--development` flag.
- Rename `--plan` flag of `viridian create-cluster` to `cluster-type` and do not limit the choice to `SERVERLESS`.(The default is `DEVMODE`).
- Add  `viridian list-cluster-types` command.
- Add `viridian import-config` command which imports the cluster configuration from a Viridian cluster.
- Rename `stop-cluster` to `pause-cluster`.
- Revamp the Viridian errors:
  -  Log the full Viridian error, but do not display JSON in the user error message.
  - Do not display “did you login” except there’s an authentication issue.
- Add `--yes` flag to `viridian delete-custom-class`