### PR TITLE
[CLC-188] Refactor Jet Support

### DIFF
--- a/base/commands/job/common.go
+++ b/base/commands/job/common.go
@@ -2,24 +2,17 @@ package job
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
-	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/types"
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/jet"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/proto/codec"
-	"github.com/hazelcast/hazelcast-commandline-client/internal/proto/codec/control"
 )
-
-var ErrInvalidJobID = errors.New("invalid job ID")
-var ErrJobFailed = errors.New("job failed")
-var ErrJobNotFound = errors.New("job not found")
 
 func WaitJobState(ctx context.Context, ec plug.ExecContext, msg, jobNameOrID string, state int32, duration time.Duration) error {
 	ci, err := ec.ClientInternal(ctx)
@@ -31,18 +24,18 @@ func WaitJobState(ctx context.Context, ec plug.ExecContext, msg, jobNameOrID str
 			spinner.SetText(msg)
 		}
 		for {
-			jl, err := GetJobList(ctx, ci)
+			jl, err := jet.GetJobList(ctx, ci)
 			if err != nil {
 				return nil, err
 			}
-			ok, err := EnsureJobState(jl, jobNameOrID, state)
+			ok, err := jet.EnsureJobState(jl, jobNameOrID, state)
 			if err != nil {
 				return nil, err
 			}
 			if ok {
 				return nil, nil
 			}
-			ec.Logger().Debugf("Waiting %s for job %s to transition to state %s", duration.String(), jobNameOrID, statusToString(state))
+			ec.Logger().Debugf("Waiting %s for job %s to transition to state %s", duration.String(), jobNameOrID, jet.StatusToString(state))
 			time.Sleep(duration)
 		}
 	})
@@ -51,21 +44,6 @@ func WaitJobState(ctx context.Context, ec plug.ExecContext, msg, jobNameOrID str
 	}
 	stop()
 	return nil
-}
-
-func EnsureJobState(jobs []control.JobAndSqlSummary, jobNameOrID string, state int32) (bool, error) {
-	for _, j := range jobs {
-		if j.NameOrId == jobNameOrID {
-			if j.Status == state {
-				return true, nil
-			}
-			if j.Status == statusFailed {
-				return false, ErrJobFailed
-			}
-			return false, nil
-		}
-	}
-	return false, ErrJobNotFound
 }
 
 func idToString(id int64) string {
@@ -80,20 +58,6 @@ func idToString(id int64) string {
 		j--
 	}
 	return string(buf[:])
-}
-
-func stringToID(s string) (int64, error) {
-	// first try whether it's an int
-	i, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		// otherwise this can be an ID
-		s = strings.Replace(s, "-", "", -1)
-		i, err = strconv.ParseInt(s, 16, 64)
-		if err != nil {
-			return 0, fmt.Errorf("invalid ID: %s: %w", s, err)
-		}
-	}
-	return i, nil
 }
 
 func terminateJob(ctx context.Context, ec plug.ExecContext, jobID int64, nameOrID string, terminateMode int32, text string, waitState int32) error {
@@ -124,83 +88,4 @@ func terminateJob(ctx context.Context, ec plug.ExecContext, jobID int64, nameOrI
 		}
 	}
 	return nil
-}
-
-func GetJobList(ctx context.Context, ci *hazelcast.ClientInternal) ([]control.JobAndSqlSummary, error) {
-	req := codec.EncodeJetGetJobAndSqlSummaryListRequest()
-	resp, err := ci.InvokeOnRandomTarget(ctx, req, nil)
-	if err != nil {
-		return nil, err
-	}
-	ls := codec.DecodeJetGetJobAndSqlSummaryListResponse(resp)
-	return ls, nil
-}
-
-func makeJobNameIDMaps(jobList []control.JobAndSqlSummary) (jobNameToID map[string]int64, idToJobName map[int64]string) {
-	jobNameToID = make(map[string]int64, len(jobList))
-	idToJobName = make(map[int64]string, len(jobList))
-	for _, j := range jobList {
-		idToJobName[j.JobId] = j.NameOrId
-		if j.Status == statusFailed || j.Status == statusCompleted {
-			continue
-		}
-		jobNameToID[j.NameOrId] = j.JobId
-
-	}
-	return jobNameToID, idToJobName
-}
-
-type jobNameToIDMap struct {
-	nameToID map[string]int64
-	IDToName map[int64]string
-}
-
-func newJobNameToIDMap(ctx context.Context, ec plug.ExecContext, forceLoadJobList bool) (*jobNameToIDMap, error) {
-	hasJobName := false
-	for _, arg := range ec.Args() {
-		if _, err := stringToID(arg); err != nil {
-			hasJobName = true
-			break
-		}
-	}
-	if !hasJobName && !forceLoadJobList {
-		// relies on m.GetIDForName returning the numeric jobID
-		// if s is a UUID
-		return &jobNameToIDMap{
-			nameToID: map[string]int64{},
-			IDToName: map[int64]string{},
-		}, nil
-	}
-	ci, err := ec.ClientInternal(ctx)
-	if err != nil {
-		return nil, err
-	}
-	jl, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
-		sp.SetText("Getting job list")
-		return GetJobList(ctx, ci)
-	})
-	if err != nil {
-		return nil, err
-	}
-	stop()
-	n2i, i2j := makeJobNameIDMaps(jl.([]control.JobAndSqlSummary))
-	return &jobNameToIDMap{
-		nameToID: n2i,
-		IDToName: i2j,
-	}, nil
-}
-
-func (m jobNameToIDMap) GetIDForName(idOrName string) (int64, bool) {
-	id, err := stringToID(idOrName)
-	// note that comparing err to nil
-	if err == nil {
-		return id, true
-	}
-	v, ok := m.nameToID[idOrName]
-	return v, ok
-}
-
-func (m jobNameToIDMap) GetNameForID(id int64) (string, bool) {
-	v, ok := m.IDToName[id]
-	return v, ok
 }

--- a/base/commands/job/const.go
+++ b/base/commands/job/const.go
@@ -1,19 +1,13 @@
 package job
 
 const (
-	terminateModeRestartGraceful int32 = 0
-	terminateModeRestartForceful int32 = 1
-	terminateModeSuspendGraceful int32 = 2
-	terminateModeSuspendForceful int32 = 3
-	terminateModeCancelGraceful  int32 = 4
-	terminateModeCancelForceful  int32 = 5
-	flagForce                          = "force"
-	flagIncludeSQL                     = "include-sql"
-	flagIncludeUserCancelled           = "include-user-cancelled"
-	flagName                           = "name"
-	flagSnapshot                       = "snapshot"
-	flagClass                          = "class"
-	flagCancel                         = "cancel"
-	flagRetries                        = "retries"
-	flagWait                           = "wait"
+	flagForce                = "force"
+	flagIncludeSQL           = "include-sql"
+	flagIncludeUserCancelled = "include-user-cancelled"
+	flagName                 = "name"
+	flagSnapshot             = "snapshot"
+	flagClass                = "class"
+	flagCancel               = "cancel"
+	flagRetries              = "retries"
+	flagWait                 = "wait"
 )

--- a/base/commands/job/const.go
+++ b/base/commands/job/const.go
@@ -1,27 +1,19 @@
 package job
 
 const (
-	terminateModeRestartGraceful     int32 = 0
-	terminateModeRestartForceful     int32 = 1
-	terminateModeSuspendGraceful     int32 = 2
-	terminateModeSuspendForceful     int32 = 3
-	terminateModeCancelGraceful      int32 = 4
-	terminateModeCancelForceful      int32 = 5
-	flagForce                              = "force"
-	flagIncludeSQL                         = "include-sql"
-	flagIncludeUserCancelled               = "include-user-cancelled"
-	flagName                               = "name"
-	flagSnapshot                           = "snapshot"
-	flagClass                              = "class"
-	flagCancel                             = "cancel"
-	flagRetries                            = "retries"
-	flagWait                               = "wait"
-	statusNotRunning                       = 0
-	statusStarting                         = 1
-	statusRunning                          = 2
-	statusSuspended                        = 3
-	statusSuspendedExportingSnapshot       = 4
-	statusCompleting                       = 5
-	statusFailed                           = 6
-	statusCompleted                        = 7
+	terminateModeRestartGraceful int32 = 0
+	terminateModeRestartForceful int32 = 1
+	terminateModeSuspendGraceful int32 = 2
+	terminateModeSuspendForceful int32 = 3
+	terminateModeCancelGraceful  int32 = 4
+	terminateModeCancelForceful  int32 = 5
+	flagForce                          = "force"
+	flagIncludeSQL                     = "include-sql"
+	flagIncludeUserCancelled           = "include-user-cancelled"
+	flagName                           = "name"
+	flagSnapshot                       = "snapshot"
+	flagClass                          = "class"
+	flagCancel                         = "cancel"
+	flagRetries                        = "retries"
+	flagWait                           = "wait"
 )

--- a/base/commands/job/job_export_snapshot.go
+++ b/base/commands/job/job_export_snapshot.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/jet"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/proto/codec"
 )
@@ -30,7 +31,7 @@ func (cm ExportSnapshotCmd) Exec(ctx context.Context, ec plug.ExecContext) error
 	if err != nil {
 		return err
 	}
-	var jm *jobNameToIDMap
+	var jm *jet.JobNameToIDMap
 	var jid int64
 	var ok bool
 	jobNameOrID := ec.Args()[0]
@@ -38,13 +39,13 @@ func (cm ExportSnapshotCmd) Exec(ctx context.Context, ec plug.ExecContext) error
 	cancel := ec.Props().GetBool(flagCancel)
 	if name == "" {
 		// create the default snapshot name
-		jm, err = newJobNameToIDMap(ctx, ec, true)
+		jm, err = jet.NewJobNameToIDMap(ctx, ec, true)
 		if err != nil {
 			return err
 		}
 		jid, ok = jm.GetIDForName(jobNameOrID)
 		if !ok {
-			return ErrInvalidJobID
+			return jet.ErrInvalidJobID
 		}
 		name, ok = jm.GetNameForID(jid)
 		if !ok {
@@ -52,13 +53,13 @@ func (cm ExportSnapshotCmd) Exec(ctx context.Context, ec plug.ExecContext) error
 		}
 		name = autoGenerateSnapshotName(name)
 	} else {
-		jm, err = newJobNameToIDMap(ctx, ec, false)
+		jm, err = jet.NewJobNameToIDMap(ctx, ec, false)
 		if err != nil {
 			return err
 		}
 		jid, ok = jm.GetIDForName(jobNameOrID)
 		if !ok {
-			return ErrInvalidJobID
+			return jet.ErrInvalidJobID
 		}
 	}
 	if err != nil {

--- a/base/commands/job/job_list.go
+++ b/base/commands/job/job_list.go
@@ -34,7 +34,8 @@ func (cm ListCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	}
 	ls, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
 		sp.SetText("Getting the job list")
-		return jet.GetJobList(ctx, ci)
+		j := jet.New(ci, sp, ec.Logger())
+		return j.GetJobList(ctx)
 	})
 	if err != nil {
 		return err

--- a/base/commands/job/job_resume.go
+++ b/base/commands/job/job_resume.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/jet"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/proto/codec"
 )
@@ -27,14 +28,14 @@ func (cm ResumeCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	if err != nil {
 		return err
 	}
-	jm, err := newJobNameToIDMap(ctx, ec, false)
+	jm, err := jet.NewJobNameToIDMap(ctx, ec, false)
 	if err != nil {
 		return err
 	}
 	nameOrID := ec.Args()[0]
 	jid, ok := jm.GetIDForName(nameOrID)
 	if !ok {
-		return ErrInvalidJobID
+		return jet.ErrInvalidJobID
 	}
 	_, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
 		sp.SetText(fmt.Sprintf("Resuming job: %s", idToString(jid)))
@@ -51,7 +52,7 @@ func (cm ResumeCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	if ec.Props().GetBool(flagWait) {
 		msg := fmt.Sprintf("Waiting for job %s to start", nameOrID)
 		ec.Logger().Info(msg)
-		err = WaitJobState(ctx, ec, msg, nameOrID, statusRunning, 2*time.Second)
+		err = WaitJobState(ctx, ec, msg, nameOrID, jet.JobStatusRunning, 2*time.Second)
 		if err != nil {
 			return err
 		}

--- a/base/commands/job/job_resume.go
+++ b/base/commands/job/job_resume.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/jet"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
-	"github.com/hazelcast/hazelcast-commandline-client/internal/proto/codec"
 )
 
 type ResumeCmd struct{}
@@ -28,7 +27,7 @@ func (cm ResumeCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	if err != nil {
 		return err
 	}
-	jm, err := jet.NewJobNameToIDMap(ctx, ec, false)
+	jm, err := NewJobNameToIDMap(ctx, ec, false)
 	if err != nil {
 		return err
 	}
@@ -39,11 +38,8 @@ func (cm ResumeCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	}
 	_, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
 		sp.SetText(fmt.Sprintf("Resuming job: %s", idToString(jid)))
-		req := codec.EncodeJetResumeJobRequest(jid)
-		if _, err := ci.InvokeOnRandomTarget(ctx, req, nil); err != nil {
-			return nil, err
-		}
-		return nil, nil
+		j := jet.New(ci, sp, ec.Logger())
+		return nil, j.ResumeJob(ctx, jid)
 	})
 	if err != nil {
 		return err

--- a/base/commands/job/job_submit.go
+++ b/base/commands/job/job_submit.go
@@ -86,7 +86,8 @@ func submitJar(ctx context.Context, ci *hazelcast.ClientInternal, ec plug.ExecCo
 			} else {
 				sp.SetText(fmt.Sprintf("%s: retry %d", msg, try))
 			}
-			return j.SubmitJob(ctx, path, jobName, className, snapshot, args)
+			br := jet.CreateBinaryReaderForPath(path)
+			return j.SubmitJob(ctx, path, jobName, className, snapshot, args, br)
 		})
 		if err != nil {
 			return nil, err

--- a/base/commands/job/job_terminate.go
+++ b/base/commands/job/job_terminate.go
@@ -39,7 +39,7 @@ func (cm TerminateCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	if ec.Props().GetBool(flagForce) {
 		tm = cm.terminateModeForce
 	}
-	jm, err := jet.NewJobNameToIDMap(ctx, ec, false)
+	jm, err := NewJobNameToIDMap(ctx, ec, false)
 	if err != nil {
 		return err
 	}
@@ -63,8 +63,8 @@ func init() {
 		name:               "cancel",
 		longHelp:           "Cancels the job with the given ID or name.",
 		shortHelp:          "Cancels the job with the given ID or name",
-		terminateMode:      terminateModeCancelGraceful,
-		terminateModeForce: terminateModeCancelForceful,
+		terminateMode:      jet.TerminateModeCancelGraceful,
+		terminateModeForce: jet.TerminateModeCancelForceful,
 		msg:                "Cancelling the job",
 		waitState:          jet.JobStatusFailed,
 	}))
@@ -72,8 +72,8 @@ func init() {
 		name:               "suspend",
 		longHelp:           "Suspends the job with the given ID or name.",
 		shortHelp:          "Suspends the job with the given ID or name",
-		terminateMode:      terminateModeSuspendGraceful,
-		terminateModeForce: terminateModeSuspendForceful,
+		terminateMode:      jet.TerminateModeSuspendGraceful,
+		terminateModeForce: jet.TerminateModeSuspendForceful,
 		msg:                "Suspending the job",
 		waitState:          jet.JobStatusSuspended,
 	}))
@@ -81,8 +81,8 @@ func init() {
 		name:               "restart",
 		longHelp:           "Restarts the job with the given ID or name.",
 		shortHelp:          "Restarts the job with the given ID or name",
-		terminateMode:      terminateModeRestartGraceful,
-		terminateModeForce: terminateModeRestartForceful,
+		terminateMode:      jet.TerminateModeRestartGraceful,
+		terminateModeForce: jet.TerminateModeRestartForceful,
 		msg:                "Restarting the job",
 		waitState:          jet.JobStatusRunning,
 	}))

--- a/base/commands/job/job_terminate.go
+++ b/base/commands/job/job_terminate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hazelcast/hazelcast-commandline-client/clc"
 	. "github.com/hazelcast/hazelcast-commandline-client/internal/check"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/jet"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
 )
 
@@ -38,14 +39,14 @@ func (cm TerminateCmd) Exec(ctx context.Context, ec plug.ExecContext) error {
 	if ec.Props().GetBool(flagForce) {
 		tm = cm.terminateModeForce
 	}
-	jm, err := newJobNameToIDMap(ctx, ec, false)
+	jm, err := jet.NewJobNameToIDMap(ctx, ec, false)
 	if err != nil {
 		return err
 	}
 	arg := ec.Args()[0]
 	jid, ok := jm.GetIDForName(arg)
 	if !ok {
-		return ErrInvalidJobID
+		return jet.ErrInvalidJobID
 	}
 	if err = terminateJob(ctx, ec, jid, arg, tm, cm.msg, cm.waitState); err != nil {
 		return err
@@ -65,7 +66,7 @@ func init() {
 		terminateMode:      terminateModeCancelGraceful,
 		terminateModeForce: terminateModeCancelForceful,
 		msg:                "Cancelling the job",
-		waitState:          statusFailed,
+		waitState:          jet.JobStatusFailed,
 	}))
 	Must(plug.Registry.RegisterCommand("job:suspend", &TerminateCmd{
 		name:               "suspend",
@@ -74,7 +75,7 @@ func init() {
 		terminateMode:      terminateModeSuspendGraceful,
 		terminateModeForce: terminateModeSuspendForceful,
 		msg:                "Suspending the job",
-		waitState:          statusSuspended,
+		waitState:          jet.JobStatusSuspended,
 	}))
 	Must(plug.Registry.RegisterCommand("job:restart", &TerminateCmd{
 		name:               "restart",
@@ -83,6 +84,6 @@ func init() {
 		terminateMode:      terminateModeRestartGraceful,
 		terminateModeForce: terminateModeRestartForceful,
 		msg:                "Restarting the job",
-		waitState:          statusRunning,
+		waitState:          jet.JobStatusRunning,
 	}))
 }

--- a/base/commands/job/job_test.go
+++ b/base/commands/job/job_test.go
@@ -1,9 +1,6 @@
 package job
 
 import (
-	"bytes"
-	"fmt"
-	"io"
 	"strconv"
 	"testing"
 
@@ -76,62 +73,4 @@ func TestStringToID(t *testing.T) {
 			assert.Equal(t, tc.id, id)
 		})
 	}
-}
-
-func TestBatch(t *testing.T) {
-	b100 := newByteArray(100)
-	testCases := []struct {
-		b       *bytes.Buffer
-		bs      int
-		batches [][]byte
-	}{
-		{
-			b:       bytes.NewBuffer(b100),
-			bs:      100,
-			batches: [][]byte{b100},
-		},
-		{
-			b:       bytes.NewBuffer(b100),
-			bs:      50,
-			batches: [][]byte{b100[:50], b100[50:]},
-		},
-		{
-			b:       bytes.NewBuffer(b100),
-			bs:      30,
-			batches: [][]byte{b100[0:30], b100[30:60], b100[60:90], b100[90:]},
-		},
-		{
-			b:       bytes.NewBuffer(nil),
-			bs:      1,
-			batches: [][]byte{},
-		},
-	}
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(fmt.Sprintf("size %d, %d batches", tc.b.Len(), tc.bs), func(t *testing.T) {
-			bb := newBatch(tc.b, tc.bs)
-			result := [][]byte{}
-			for {
-				b, _, err := bb.Next()
-				if err == io.EOF {
-					break
-				}
-				if err != nil {
-					t.Fatal(err)
-				}
-				bc := make([]byte, len(b))
-				copy(bc, b)
-				result = append(result, bc)
-			}
-			assert.Equal(t, tc.batches, result)
-		})
-	}
-}
-
-func newByteArray(size int) []byte {
-	r := make([]byte, size)
-	for i := 0; i < size; i++ {
-		r[i] = byte(i)
-	}
-	return r
 }

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1,0 +1,26 @@
+package cluster
+
+import (
+	"context"
+	"math/rand"
+
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/cluster"
+	"github.com/hazelcast/hazelcast-go-client/types"
+)
+
+func RandomMember(ctx context.Context, ci *hazelcast.ClientInternal) (types.UUID, error) {
+	var mi cluster.MemberInfo
+	for {
+		if ctx.Err() != nil {
+			return types.UUID{}, ctx.Err()
+		}
+		mems := ci.OrderedMembers()
+		if len(mems) != 0 {
+			mi = mems[rand.Intn(len(mems))]
+			if ci.ConnectedToMember(mi.UUID) {
+				return mi.UUID, nil
+			}
+		}
+	}
+}

--- a/internal/jet/errors.go
+++ b/internal/jet/errors.go
@@ -1,0 +1,9 @@
+package jet
+
+import "errors"
+
+var (
+	ErrInvalidJobID = errors.New("invalid job ID")
+	ErrJobFailed    = errors.New("job failed")
+	ErrJobNotFound  = errors.New("job not found")
+)

--- a/internal/jet/jet_test.go
+++ b/internal/jet/jet_test.go
@@ -1,0 +1,68 @@
+package jet
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatch(t *testing.T) {
+	b100 := newByteArray(100)
+	testCases := []struct {
+		b       *bytes.Buffer
+		bs      int
+		batches [][]byte
+	}{
+		{
+			b:       bytes.NewBuffer(b100),
+			bs:      100,
+			batches: [][]byte{b100},
+		},
+		{
+			b:       bytes.NewBuffer(b100),
+			bs:      50,
+			batches: [][]byte{b100[:50], b100[50:]},
+		},
+		{
+			b:       bytes.NewBuffer(b100),
+			bs:      30,
+			batches: [][]byte{b100[0:30], b100[30:60], b100[60:90], b100[90:]},
+		},
+		{
+			b:       bytes.NewBuffer(nil),
+			bs:      1,
+			batches: [][]byte{},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("size %d, %d batches", tc.b.Len(), tc.bs), func(t *testing.T) {
+			bb := newBatch(tc.b, tc.bs)
+			result := [][]byte{}
+			for {
+				b, _, err := bb.Next()
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				bc := make([]byte, len(b))
+				copy(bc, b)
+				result = append(result, bc)
+			}
+			assert.Equal(t, tc.batches, result)
+		})
+	}
+}
+
+func newByteArray(size int) []byte {
+	r := make([]byte, size)
+	for i := 0; i < size; i++ {
+		r[i] = byte(i)
+	}
+	return r
+}

--- a/internal/jet/job.go
+++ b/internal/jet/job.go
@@ -1,0 +1,103 @@
+package jet
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/types"
+
+	"github.com/hazelcast/hazelcast-commandline-client/internal/cluster"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/log"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/proto/codec"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/proto/codec/control"
+)
+
+type spinner interface {
+	SetProgress(progress float32)
+}
+
+type Jet struct {
+	ci *hazelcast.ClientInternal
+	sp spinner
+	lg log.Logger
+}
+
+func New(ci *hazelcast.ClientInternal, sp spinner, lg log.Logger) *Jet {
+	return &Jet{
+		ci: ci,
+		sp: sp,
+		lg: lg,
+	}
+}
+
+func (j Jet) SubmitJob(ctx context.Context, path, jobName, className, snapshot string, args []string) error {
+	_, fn := filepath.Split(path)
+	fn = strings.TrimSuffix(fn, ".jar")
+	j.sp.SetProgress(0)
+	hashBin, err := hashOfPath(path)
+	if err != nil {
+		return err
+	}
+	hash := fmt.Sprintf("%x", hashBin)
+	sid := types.NewUUID()
+	mrReq := codec.EncodeJetUploadJobMetaDataRequest(sid, false, fn, hash, snapshot, jobName, className, args)
+	mem, err := cluster.RandomMember(ctx, j.ci)
+	if err != nil {
+		return err
+	}
+	if _, err = j.ci.InvokeOnMember(ctx, mrReq, mem, nil); err != nil {
+		return err
+	}
+	if err != nil {
+		return fmt.Errorf("uploading job metadata: %w", err)
+	}
+	pc, err := partCountOf(path, defaultBatchSize)
+	if err != nil {
+		return err
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	j.lg.Info("Sending %s in %d batch(es)", path, pc)
+	bb := newBatch(f, defaultBatchSize)
+	for i := int32(0); i < int32(pc); i++ {
+		bin, hashBin, err := bb.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("sending the job: %w", err)
+		}
+		part := i + 1
+		hash := fmt.Sprintf("%x", hashBin)
+		mrReq = codec.EncodeJetUploadJobMultipartRequest(sid, part, int32(pc), bin, int32(len(bin)), hash)
+		if _, err := j.ci.InvokeOnMember(ctx, mrReq, mem, nil); err != nil {
+			return fmt.Errorf("uploading part %d: %w", part, err)
+		}
+		j.sp.SetProgress(float32(part) / float32(pc))
+	}
+	j.sp.SetProgress(1)
+	return nil
+}
+
+func EnsureJobState(jobs []control.JobAndSqlSummary, jobNameOrID string, state int32) (bool, error) {
+	for _, j := range jobs {
+		if j.NameOrId == jobNameOrID {
+			if j.Status == state {
+				return true, nil
+			}
+			if j.Status == JobStatusFailed {
+				return false, ErrJobFailed
+			}
+			return false, nil
+		}
+	}
+	return false, ErrJobNotFound
+}

--- a/internal/jet/job.go
+++ b/internal/jet/job.go
@@ -87,6 +87,40 @@ func (j Jet) SubmitJob(ctx context.Context, path, jobName, className, snapshot s
 	return nil
 }
 
+func (j Jet) GetJobList(ctx context.Context) ([]control.JobAndSqlSummary, error) {
+	req := codec.EncodeJetGetJobAndSqlSummaryListRequest()
+	resp, err := j.ci.InvokeOnRandomTarget(ctx, req, nil)
+	if err != nil {
+		return nil, err
+	}
+	ls := codec.DecodeJetGetJobAndSqlSummaryListResponse(resp)
+	return ls, nil
+}
+
+func (j Jet) TerminateJob(ctx context.Context, jobID int64, terminateMode int32) error {
+	req := codec.EncodeJetTerminateJobRequest(jobID, terminateMode, types.UUID{})
+	if _, err := j.ci.InvokeOnRandomTarget(ctx, req, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (j Jet) ExportSnapshot(ctx context.Context, jobID int64, name string, cancel bool) error {
+	req := codec.EncodeJetExportSnapshotRequest(jobID, name, cancel)
+	if _, err := j.ci.InvokeOnRandomTarget(ctx, req, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (j Jet) ResumeJob(ctx context.Context, jobID int64) error {
+	req := codec.EncodeJetResumeJobRequest(jobID)
+	if _, err := j.ci.InvokeOnRandomTarget(ctx, req, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
 func EnsureJobState(jobs []control.JobAndSqlSummary, jobNameOrID string, state int32) (bool, error) {
 	for _, j := range jobs {
 		if j.NameOrId == jobNameOrID {

--- a/internal/jet/util.go
+++ b/internal/jet/util.go
@@ -1,0 +1,205 @@
+package jet
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/hazelcast/hazelcast-go-client"
+
+	"github.com/hazelcast/hazelcast-commandline-client/clc"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/plug"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/proto/codec"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/proto/codec/control"
+)
+
+const (
+	defaultBatchSize                    = 2 * 1024 * 1024 // 10MB
+	JobStatusNotRunning                 = 0
+	JobStatusStarting                   = 1
+	JobStatusRunning                    = 2
+	JobStatusSuspended                  = 3
+	JobStatusSuspendedExportingSnapshot = 4
+	JobStatusCompleting                 = 5
+	JobStatusFailed                     = 6
+	JobStatusCompleted                  = 7
+)
+
+func hashOfPath(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return calculateHash(f)
+}
+
+func calculateHash(r io.Reader) ([]byte, error) {
+	h := sha256.New()
+	_, err := io.Copy(h, r)
+	if err != nil {
+		return nil, err
+	}
+	buf := make([]byte, 0, 32)
+	b := h.Sum(buf)
+	return b, nil
+}
+
+func partCountOf(path string, partSize int) (int, error) {
+	st, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return int(math.Ceil(float64(st.Size()) / float64(partSize))), nil
+}
+
+func StatusToString(status int32) string {
+	switch status {
+	case JobStatusNotRunning:
+		return "NOT_RUNNING"
+	case JobStatusStarting:
+		return "STARTING"
+	case JobStatusRunning:
+		return "RUNNING"
+	case JobStatusSuspended:
+		return "SUSPENDED"
+	case JobStatusSuspendedExportingSnapshot:
+		return "SUSPENDED_EXPORTING_SNAPSHOT"
+	case JobStatusCompleting:
+		return "COMPLETING"
+	case JobStatusFailed:
+		return "FAILED"
+	case JobStatusCompleted:
+		return "COMPLETED"
+	}
+	return "UNKNOWN"
+}
+
+type binBatch struct {
+	reader io.Reader
+	buf    []byte
+}
+
+func newBatch(reader io.Reader, batchSize int) *binBatch {
+	if batchSize < 1 {
+		panic("newBatch: batchSize must be positive")
+	}
+	return &binBatch{
+		reader: reader,
+		buf:    make([]byte, batchSize),
+	}
+}
+
+// Next returns the next batch of bytes.
+// Make sure to copy it before calling Next again.
+func (bb *binBatch) Next() ([]byte, []byte, error) {
+	n, err := bb.reader.Read(bb.buf)
+	if err != nil {
+		return nil, nil, err
+	}
+	b := bb.buf[0:n:n]
+	h, err := calculateHash(bytes.NewBuffer(b))
+	if err != nil {
+		return nil, nil, err
+	}
+	return b, h, nil
+}
+
+func stringToID(s string) (int64, error) {
+	// first try whether it's an int
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		// otherwise this can be an ID
+		s = strings.Replace(s, "-", "", -1)
+		i, err = strconv.ParseInt(s, 16, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid ID: %s: %w", s, err)
+		}
+	}
+	return i, nil
+}
+
+func MakeJobNameIDMaps(jobList []control.JobAndSqlSummary) (jobNameToID map[string]int64, idToJobName map[int64]string) {
+	jobNameToID = make(map[string]int64, len(jobList))
+	idToJobName = make(map[int64]string, len(jobList))
+	for _, j := range jobList {
+		idToJobName[j.JobId] = j.NameOrId
+		if j.Status == JobStatusFailed || j.Status == JobStatusCompleted {
+			continue
+		}
+		jobNameToID[j.NameOrId] = j.JobId
+
+	}
+	return jobNameToID, idToJobName
+}
+
+type JobNameToIDMap struct {
+	nameToID map[string]int64
+	IDToName map[int64]string
+}
+
+func NewJobNameToIDMap(ctx context.Context, ec plug.ExecContext, forceLoadJobList bool) (*JobNameToIDMap, error) {
+	hasJobName := false
+	for _, arg := range ec.Args() {
+		if _, err := stringToID(arg); err != nil {
+			hasJobName = true
+			break
+		}
+	}
+	if !hasJobName && !forceLoadJobList {
+		// relies on m.GetIDForName returning the numeric jobID
+		// if s is a UUID
+		return &JobNameToIDMap{
+			nameToID: map[string]int64{},
+			IDToName: map[int64]string{},
+		}, nil
+	}
+	ci, err := ec.ClientInternal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	jl, stop, err := ec.ExecuteBlocking(ctx, func(ctx context.Context, sp clc.Spinner) (any, error) {
+		sp.SetText("Getting job list")
+		return GetJobList(ctx, ci)
+	})
+	if err != nil {
+		return nil, err
+	}
+	stop()
+	n2i, i2j := MakeJobNameIDMaps(jl.([]control.JobAndSqlSummary))
+	return &JobNameToIDMap{
+		nameToID: n2i,
+		IDToName: i2j,
+	}, nil
+}
+
+func (m JobNameToIDMap) GetIDForName(idOrName string) (int64, bool) {
+	id, err := stringToID(idOrName)
+	// note that comparing err to nil
+	if err == nil {
+		return id, true
+	}
+	v, ok := m.nameToID[idOrName]
+	return v, ok
+}
+
+func (m JobNameToIDMap) GetNameForID(id int64) (string, bool) {
+	v, ok := m.IDToName[id]
+	return v, ok
+}
+
+func GetJobList(ctx context.Context, ci *hazelcast.ClientInternal) ([]control.JobAndSqlSummary, error) {
+	req := codec.EncodeJetGetJobAndSqlSummaryListRequest()
+	resp, err := ci.InvokeOnRandomTarget(ctx, req, nil)
+	if err != nil {
+		return nil, err
+	}
+	ls := codec.DecodeJetGetJobAndSqlSummaryListResponse(resp)
+	return ls, nil
+}


### PR DESCRIPTION
* We will need to use Jet functionality outside of `jet` command, so moved core Jet code to a separate package.
* Added support for submitting the job from a reader.