### PR TITLE
DOCS-521_Update MC and CLC versions

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -2,21 +2,21 @@ name: clc
 title: Hazelcast CLC
 start_page: overview.adoc
 # Version in the URL
-version: '5.3-snapshot'
+version: '5.4-snapshot'
 # Version in the version selector (we display only the latest major.minor version)
-display_version: '5.3-SNAPSHOT'
+display_version: '5.4-SNAPSHOT'
 # Displays a banner to inform users that this is a prerelease version 
 prerelease: true
 asciidoc:
   attributes:
     # The full major.minor.patch version, which is used as a variable in the docs for things like download links
-    full-version: '5.3.0-SNAPSHOT'
+    full-version: '5.4.0-SNAPSHOT'
     # Allows us to use UI macros. See https://docs.asciidoctor.org/asciidoc/latest/macros/ui-macros/
     experimental: true
     snapshot: true
     page-toclevels: 3@
     # Required Go version for build
     go-version: 1.19
-    page-latest-supported-mc: '5.3-snapshot'
+    page-latest-supported-mc: '5.3.1-snapshot'
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
Updated antora.yml:

- Links to Management Center showing as broken as using page-latest-supported-mc: '5.3-snapshot' rather than '5.3.1-snapshot'
- Added new snapshot details.
