### PR TITLE
DOCS-504 Updates to Jet Job Tutorial

### DIFF
--- a/docs/modules/ROOT/pages/jet-job-management.adoc
+++ b/docs/modules/ROOT/pages/jet-job-management.adoc
@@ -96,7 +96,7 @@ Submitting the sample Jet job generates a stream of numbers and creates a link:h
 +
 [source,shell]
 ----
-clc -c dev job submit build/libs/simple-streaming-pipeline-1.0-SNAPSHOT-all.jar --wait
+clc -c dev job submit build/libs/simple-streaming-pipeline-1.0-SNAPSHOT-all.jar --name simple-pipeline --wait
 ----
 +
 The Hazelcast CLC waits until the job starts to run.
@@ -108,16 +108,64 @@ The Hazelcast CLC waits until the job starts to run.
 clc -c dev job list
 ----
 +
-. Run this command to see how the number of entries in `my-map` increases.
+. See how the size of `my-map` increases as entries are written to it.
++
+
+[tabs] 
+==== 
+Unix::
++
+.	Create a new shell script in your favorite text editor. For example:
 +
 [source,shell]
 ----
-while true; do \
-  clc -c dev map size -n my-map; sleep 3; \
+vi monitor.sh
+----
+. Add the following:
++
+[source,shell]
+----
+#! /bin/bash
+while true; 
+do clc -c dev map size -n my-map; sleep 3;
 done
 ----
 
-. Press kbd:[Ctrl + C] to cancel the command.
+. Run your script.
++
+[source,shell]
+----
+./monitor.sh
+----
+. Press kbd:[Ctrl + C] when you're ready to cancel the script.
+
+Windows::
++
+. Create a new batch file in your favorite text editor. For example:
++
+[source,shell]
+----
+notepad monitor.bat
+----
+. Add the following:
++
+[source,shell]
+----
+@echo off
+:start
+clc -c dev map size -n my-map
+timeout 5
+goto start
+----
+. Run the batch file.
++
+[source,shell]
+----
+monitor
+----
+. Press kbd:[Ctrl + C] when you're ready to cancel the script.
+====
+
 
 [[step-6-cancel-jet-job]]
 == Step 6. Cancel the Jet job
@@ -126,19 +174,10 @@ done
 +
 [source,shell]
 ----
-clc -c dev job cancel prime-job
+clc -c dev job cancel simple-pipeline
 ----
 
-. See how the size of the `my-map` no longer increases.
-+
-[source,shell]
-----
-while true; do \
-  clc -c dev map size -n my-map; sleep 3; \
-done
-----
-
-. Press kbd:[Ctrl + C] to cancel the command.
+. Run your script (from step 5) to see the size of `my-map` now.
 
 == Summary
 

--- a/docs/modules/ROOT/pages/jet-job-management.adoc
+++ b/docs/modules/ROOT/pages/jet-job-management.adoc
@@ -1,5 +1,5 @@
 = Get Started With Hazelcast Jet Job Management
-:description: In this tutorial, you’ll learn the basics of how to manage stream-processing pipelines using the Hazelcast CLC with Hazelcast {hazelcast-cloud}. You’ll see how to connect to a {hazelcast-cloud} cluster and submit a sample Jet job that generates a stream of numbers. You’ll also learn how to use simple commands to monitor and cancel jobs.
+:description: In this tutorial, you'll learn the basics of how to manage stream-processing pipelines using the Hazelcast CLC with Hazelcast {hazelcast-cloud}. You'll see how to connect to a {hazelcast-cloud} cluster and submit a sample Jet job that generates a stream of numbers. You'll also learn how to use simple commands to monitor and cancel jobs.
 
 {description}
 
@@ -8,7 +8,7 @@
 You need the following:
 
 - xref:install-clc.adoc[Hazelcast CLC] installed on your local machine
-- One running Hazelcast {hazelcast-cloud} cluster. You can create a xref:managing-viridian-clusters.adoc#creating-a-cluster-on-viridian[{hazelcast-cloud} development cluster] using the Hazelcast CLC..adoc#creating-a-cluster-on-viridian[{hazelcast-cloud} development cluster] with CLC.
+- One running Hazelcast {hazelcast-cloud} cluster. You can create a xref:managing-viridian-clusters.adoc#creating-a-cluster-on-viridian[{hazelcast-cloud} development cluster] using the Hazelcast CLC.
 - xref:cloud:ROOT:developer.adoc[{hazelcast-cloud} API key and secret]
 - JRE 8 or above.
 - Gradle 8 or above.
@@ -28,7 +28,7 @@ clc viridian login
 . When prompted, enter your API key and secret. If both are correct, the token is retrieved and saved.
 
 [[step-2-list-cluster-details]]
-== Step 1. List Cluster Details
+== Step 2. List Cluster Details
 
 Next, check that the Hazelcast CLC can access your cluster by running the following command:
 
@@ -42,9 +42,9 @@ The details of all clusters linked to your Hazelcast {hazelcast-cloud} account a
 [[step-3-dev-configure]]
 == Step 3. Connect to Your Cluster
 
-For Hazelcast CLC to connect to your development cluster, you need to import the cluster’s configuration, including its connection details.
+For Hazelcast CLC to connect to your development cluster, you need to import the cluster's configuration, including its connection details.
 
-Run the following command to save the cluster configuration with the name dev. Replace the `$CLUSTER_NAME` placeholder with the name of your cluster.
+Run the following command to save the cluster configuration with the name `dev`. Replace the `$CLUSTER_NAME` placeholder with the name of your cluster, shown in the top-left corner of the dashboard.
 
 [source,shell]
 ----
@@ -54,14 +54,34 @@ clc viridian import-config $CLUSTER_NAME --name dev
 [[step-4-build-jet-job]]
 == Step 4. Build the Jet Job
 
-Now you’re ready to build the sample Jet job.
+Now you're ready to build the sample Jet job.
 
-The sample Jet job we use in this tutorial generates a stream of numbers and creates a link:https://hashids.org/[Hashid] for each number. The number and hashid pair is then saved to a Map with they number as the key and hashid as the value.
+. Clone the GitHub repository.
++
+[tabs] 
+====
+HTTPS:: 
++ 
+--
+```bash
+git clone https://github.com/hazelcast/hazelcast-commandline-client
 
-. Find the Jet job project in https://github.com/hazelcast/hazelcast-commandline-client[the CLC repository] under the path `examples/platform/simple-streaming-pipeline`.
+cd hazelcast-commandline-client/examples/platform/simple-streaming-pipeline
+```
+--
+SSH:: 
++ 
+--
+```bash
+git clone git@github.com:hazelcast/hazelcast-commandline-client.git
 
-Build the project with the following command:
-
+cd hazelcast-commandline-client/examples/platform/simple-streaming-pipeline
+```
+--
+====
++
+. Build the project with the following command:
++
 [source,shell]
 ----
 gradle shadowJar
@@ -70,7 +90,7 @@ gradle shadowJar
 [[step-5-submit-jet-job]]
 == Step 5. Submit and Monitor the Jet Job
 
-Submitting the sample Jet job generates a stream of numbers and creates a [hashid](https://hashids.org/) for each number. The number and hashid pair are then saved to a Map called ‘my-map`, with the number as the key and hashid as the value.
+Submitting the sample Jet job generates a stream of numbers and creates a link:https://hashids.org/[hashid] for each number. The number and hashid pair are then saved to a Map called `my-map`, with the number as the key and hashid as the value.
 
 . Execute the following command to submit the Jet job:
 +
@@ -81,14 +101,14 @@ clc -c dev job submit build/libs/simple-streaming-pipeline-1.0-SNAPSHOT-all.jar 
 +
 The Hazelcast CLC waits until the job starts to run.
 
-. Now, list the jobs in the cluster. You should see `simple-pipeline` in the `RUNNING` state
+. Now, list the jobs in the cluster. You should see `simple-pipeline` in a `RUNNING` state.
 +
 [source,shell]
 ----
 clc -c dev job list
 ----
 +
-. Run this command to see how the size of the `my-map` increases.
+. Run this command to see how the number of entries in `my-map` increases.
 +
 [source,shell]
 ----
@@ -96,6 +116,8 @@ while true; do \
   clc -c dev map size -n my-map; sleep 3; \
 done
 ----
+
+. Press kbd:[Ctrl + C] to cancel the command.
 
 [[step-6-cancel-jet-job]]
 == Step 6. Cancel the Jet job
@@ -106,8 +128,8 @@ done
 ----
 clc -c dev job cancel prime-job
 ----
-+
-. See how the size of the `my-map` remains the same.
+
+. See how the size of the `my-map` no longer increases.
 +
 [source,shell]
 ----
@@ -115,6 +137,8 @@ while true; do \
   clc -c dev map size -n my-map; sleep 3; \
 done
 ----
+
+. Press kbd:[Ctrl + C] to cancel the command.
 
 == Summary
 


### PR DESCRIPTION
Some updates to tutorial, including:

- Changes to step 4 to make it easier to use the example Jet job
- Added steps to stop looping statements

**Issues/errors**
- `clc -c dev job submit build/libs/simple-streaming-pipeline-1.0-SNAPSHOT-all.jar –wait` gave the following error `Error: --wait requires the --name to be set`. When I removed `--wait`, the command ran. For now, I have left the command as is.
- `while true; do clc -c dev map size -n my-map; sleep 3; done` does not run for Windows users. I created a small batch file and ran it. Do you want to provide this alternative for Windows users?

```
@echo off
:start
clc -c dev map size -n my-map
timeout 5
goto start

```
- `clc -c dev job cancel prime-job` gave the following error `Error: invalid job ID`.  As a workaround, I suspended the job through management center.

I will submit a separate PR to main with the same changes, when this one is merged.
