### PR TITLE
[CLC-187]: Add Global `--timeout` Flag

### DIFF
--- a/base/initializers.go
+++ b/base/initializers.go
@@ -21,6 +21,7 @@ func (g GlobalInitializer) Init(cc plug.InitContext) error {
 	updateFormatFlag(cc)
 	cc.AddBoolFlag(clc.PropertyVerbose, "", false, false, "enable verbose output")
 	cc.AddBoolFlag(clc.PropertyQuiet, "q", false, false, "disable unnecessary output")
+	cc.AddStringFlag(clc.PropertyTimeout, "t", "", false, "timeout for operation to complete")
 	lp := paths.DefaultLogPath(time.Now())
 	if !cc.Interactive() {
 		cc.AddStringFlag(clc.PropertyConfig, clc.ShortcutConfig, "", false, "set the configuration")

--- a/base/initializers.go
+++ b/base/initializers.go
@@ -21,7 +21,7 @@ func (g GlobalInitializer) Init(cc plug.InitContext) error {
 	updateFormatFlag(cc)
 	cc.AddBoolFlag(clc.PropertyVerbose, "", false, false, "enable verbose output")
 	cc.AddBoolFlag(clc.PropertyQuiet, "q", false, false, "disable unnecessary output")
-	cc.AddStringFlag(clc.PropertyTimeout, "t", "", false, "timeout for operation to complete")
+	cc.AddStringFlag(clc.PropertyTimeout, "", "", false, "timeout for operation to complete")
 	lp := paths.DefaultLogPath(time.Now())
 	if !cc.Interactive() {
 		cc.AddStringFlag(clc.PropertyConfig, clc.ShortcutConfig, "", false, "set the configuration")

--- a/clc/cmd/clc.go
+++ b/clc/cmd/clc.go
@@ -330,6 +330,15 @@ func (m *Main) createCommands() error {
 				ec.SetArgs(args)
 				ec.SetCmd(cmd)
 				ctx := context.Background()
+				t, err := parseDuration(ec.Props().GetString(clc.PropertyTimeout))
+				if err != nil {
+					return err
+				}
+				var cancel context.CancelFunc
+				if t != 0 {
+					ctx, cancel = context.WithTimeout(ctx, t)
+					defer cancel()
+				}
 				if err := m.runAugmentors(ec, props); err != nil {
 					return err
 				}

--- a/clc/cmd/utils.go
+++ b/clc/cmd/utils.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/hazelcast/hazelcast-go-client"
 
@@ -50,4 +53,22 @@ func CheckServerCompatible(ci *hazelcast.ClientInternal, targetVersion string) (
 	}
 	ok := internal.CheckVersion(sv, ">=", targetVersion)
 	return sv, ok
+}
+
+func parseDuration(duration string) (time.Duration, error) {
+	// input can be like: 10_000_000 or 10_000_000ms, so remove underscores
+	ds := strings.ReplaceAll(duration, "_", "")
+	if ds == "" {
+		return 0, nil
+	}
+	// if it can be parsed to int, then it means it does not have any prefix ms, s, m, h (default is second)
+	d, err := strconv.Atoi(ds)
+	if err == nil {
+		return time.Duration(d) * time.Second, nil
+	}
+	pd, err := time.ParseDuration(ds)
+	if err != nil {
+		return 0, err
+	}
+	return pd, nil
 }

--- a/clc/cmd/utils.go
+++ b/clc/cmd/utils.go
@@ -61,10 +61,10 @@ func parseDuration(duration string) (time.Duration, error) {
 	if ds == "" {
 		return 0, nil
 	}
-	// if it can be parsed to int, then it means it does not have any prefix ms, s, m, h (default is second)
+	// if it can be parsed to int, then it means it does not have any prefix ms, s, m, h (default is millisecond)
 	d, err := strconv.Atoi(ds)
 	if err == nil {
-		return time.Duration(d) * time.Second, nil
+		return time.Duration(d) * time.Millisecond, nil
 	}
 	pd, err := time.ParseDuration(ds)
 	if err != nil {

--- a/clc/const.go
+++ b/clc/const.go
@@ -11,6 +11,7 @@ const (
 	PropertyFormat                = "format"
 	PropertyVerbose               = "verbose"
 	PropertyQuiet                 = "quiet"
+	PropertyTimeout               = "timeout"
 	// PropertyConfig is the config name or path
 	// TODO: Separate config name and path
 	PropertyConfig              = "config"

--- a/cmd/clc/main.go
+++ b/cmd/clc/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -10,7 +11,7 @@ import (
 	clc "github.com/hazelcast/hazelcast-commandline-client/clc"
 	cmd "github.com/hazelcast/hazelcast-commandline-client/clc/cmd"
 	"github.com/hazelcast/hazelcast-commandline-client/clc/config/wizard"
-	"github.com/hazelcast/hazelcast-commandline-client/errors"
+	hzerrors "github.com/hazelcast/hazelcast-commandline-client/errors"
 )
 
 func bye(err error) {
@@ -37,13 +38,16 @@ func main() {
 	err = m.Execute(context.Background(), args...)
 	if err != nil {
 		// print the error only if it wasn't printed before
-		if _, ok := err.(errors.WrappedError); !ok {
+		if _, ok := err.(hzerrors.WrappedError); !ok {
 			fmt.Println("Error:", err)
 		}
 	}
 	// ignoring the error here
 	_ = m.Exit()
 	if err != nil {
+		if errors.Is(err, hzerrors.ErrTimeout) {
+			os.Exit(2)
+		}
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/cmd/clc/main.go
+++ b/cmd/clc/main.go
@@ -14,6 +14,12 @@ import (
 	hzerrors "github.com/hazelcast/hazelcast-commandline-client/errors"
 )
 
+const (
+	ExitCodeSuccess        = 0
+	ExitCodeGenericFailure = 1
+	ExitCodeTimeout        = 2
+)
+
 func bye(err error) {
 	_, _ = fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
 	os.Exit(1)
@@ -46,9 +52,9 @@ func main() {
 	_ = m.Exit()
 	if err != nil {
 		if errors.Is(err, hzerrors.ErrTimeout) {
-			os.Exit(2)
+			os.Exit(ExitCodeTimeout)
 		}
-		os.Exit(1)
+		os.Exit(ExitCodeGenericFailure)
 	}
-	os.Exit(0)
+	os.Exit(ExitCodeSuccess)
 }

--- a/docs/modules/ROOT/partials/global-parameters.adoc
+++ b/docs/modules/ROOT/partials/global-parameters.adoc
@@ -49,6 +49,28 @@ a|Set the log level, one of:
 |--timeout
 |Timeout for operation to complete.
 
+The duration is a string in the form of `AMOUNTunit` where `AMOUNT` is an `integer`, and `unit` is one of the following:
+
+- `ms: milliseconds`
+
+- `s: seconds`
+
+- `m: minutes`
+
+- `h: hours`
+
+Underscore (_) character is ignored in the `AMOUNT`. `unit` is optional and defaults to `s` if not specified.
+
+The following are a few of the valid DURATIONs:
+
+- `5: 5 seconds`
+
+- `5s: 5 seconds`
+
+- `10000ms: 10000 milliseconds`
+
+- `10_000_000ms: 10000000 milliseconds`
+
 WARNING: This is a client-side timeout, the operation you started maybe in progress on the server-side even if the given timeout is exceeded.
 |
 

--- a/docs/modules/ROOT/partials/global-parameters.adoc
+++ b/docs/modules/ROOT/partials/global-parameters.adoc
@@ -46,4 +46,10 @@ a|Set the log level, one of:
 |Enable output with more information.
 |false
 
+|--timeout
+|Timeout for operation to complete.
+
+WARNING: This is a client-side timeout, the operation you started maybe in progress on the server-side even if the given timeout is exceeded.
+|
+
 |===

--- a/errors/error.go
+++ b/errors/error.go
@@ -22,6 +22,7 @@ import (
 
 var (
 	ErrUserCancelled   = errors.New("cancelled")
+	ErrTimeout         = errors.New("timeout")
 	ErrNotDecoded      = errors.New("not decoded")
 	ErrNotAvailable    = errors.New("not available")
 	ErrNoClusterConfig = errors.New("no configuration was specified")


### PR DESCRIPTION
The duration is a string in the form of `AMOUNTunit` where `AMOUNT` is an `integer`, and `unit` is one of the following:

- `ms: milliseconds`

- `s: seconds`

- `m: minutes`

- `h: hours`

Underscore (_) character is ignored in the `AMOUNT`. `unit` is optional and defaults to `ms` if not specified.

The following are a few of the valid DURATIONs:

- `5: 5 seconds`

- `5s: 5 seconds`

- `10000ms: 10000 milliseconds`

- `10_000_000ms: 10000000 milliseconds`