### PR TITLE
[CLC-194] Workaround for incorrect hash stringify in Hz 5.3.0

### DIFF
--- a/base/commands/job/job_submit.go
+++ b/base/commands/job/job_submit.go
@@ -29,7 +29,7 @@ func (cm SubmitCmd) Init(cc plug.InitContext) error {
 	cc.SetCommandUsage("submit [jar-file] [arg, ...]")
 	long := fmt.Sprintf(`Submits a jar file to create a Jet job
 	
-This command requires a Viridian or a Hazelcast cluster having version %s or better.
+This command requires a Viridian or a Hazelcast cluster having version %s or newer.
 `, minServerVersion)
 	short := "Submits a jar file to create a Jet job"
 	cc.SetCommandHelp(long, short)

--- a/base/commands/job/job_submit.go
+++ b/base/commands/job/job_submit.go
@@ -29,15 +29,14 @@ func (cm SubmitCmd) Init(cc plug.InitContext) error {
 	cc.SetCommandUsage("submit [jar-file] [arg, ...]")
 	long := fmt.Sprintf(`Submits a jar file to create a Jet job
 	
-This command requires a Viridian or a Hazelcast cluster
-having version %s or better.
+This command requires a Viridian or a Hazelcast cluster having version %s or better.
 `, minServerVersion)
 	short := "Submits a jar file to create a Jet job"
 	cc.SetCommandHelp(long, short)
 	cc.AddStringFlag(flagName, "", "", false, "override the job name")
 	cc.AddStringFlag(flagSnapshot, "", "", false, "initial snapshot to start the job from")
 	cc.AddStringFlag(flagClass, "", "", false, "the class that contains the main method that creates the Jet job")
-	cc.AddIntFlag(flagRetries, "", 3, false, "number of times to retry a failed upload attempt")
+	cc.AddIntFlag(flagRetries, "", 0, false, "number of times to retry a failed upload attempt")
 	cc.AddBoolFlag(flagWait, "", false, false, "wait for the job to be started")
 	cc.SetPositionalArgCount(1, math.MaxInt)
 	return nil

--- a/internal/jet/job.go
+++ b/internal/jet/job.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/types"
@@ -91,9 +92,9 @@ func (j Jet) SubmitJob(ctx context.Context, path, jobName, className, snapshot s
 			return fmt.Errorf("sending the job: %w", err)
 		}
 		part := i + 1
-		hash := fmt.Sprintf("%x", hashBin)
+		hash = fmt.Sprintf("%x", hashBin)
 		if workaround && hash[0] == '0' {
-			hash = hash[1:]
+			hash = strings.TrimLeft(hash, "0")
 		}
 		mrReq = codec.EncodeJetUploadJobMultipartRequest(sid, part, int32(pc), bin, int32(len(bin)), hash)
 		if _, err := j.ci.InvokeOnMember(ctx, mrReq, mem, nil); err != nil {


### PR DESCRIPTION
* See: https://hazelcast.atlassian.net/browse/HZ-2492
* Also sets the default retries to `0`.