### PR TITLE
DOCS-571 Remove CLC and Viridian References

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,17 +1,17 @@
 .Get Started
 * xref:overview.adoc[What is Hazelcast CLC?]
-* xref:get-started.adoc[Get Started]
-* Tutorials
-** xref:managing-viridian-clusters.adoc[Manage Viridian Clusters]
-** xref:jet-job-management.adoc[Manage Jet Jobs]
+//* xref:get-started.adoc[Get Started]
+//* Tutorials
+//** xref:managing-viridian-clusters.adoc[Manage Viridian Clusters]
+//** xref:jet-job-management.adoc[Manage Jet Jobs]
 
 
 .Manage
 * xref:install-clc.adoc[Install]
 * xref:configuration.adoc[Configure]
-** xref:connect-to-viridian.adoc[Connect to Viridian]
+//** xref:connect-to-viridian.adoc[Connect to Viridian]
 ** xref:connect-to-platform.adoc[Connect to Platform]
-** xref:config-wizard.adoc[CLC Configuration Wizard ]
+// ** xref:config-wizard.adoc[CLC Configuration Wizard ]
 * xref:upgrade-clc.adoc[Upgrade]
 
 .Reference
@@ -29,7 +29,7 @@
 ** xref:clc-sql.adoc[]
 ** xref:clc-snapshot.adoc[]
 ** xref:clc-version.adoc[]
-** xref:clc-viridian.adoc[]
+//** xref:clc-viridian.adoc[]
 * xref:environment-variables.adoc[]
 * xref:keyboard-shortcuts.adoc[]
 

--- a/docs/modules/ROOT/pages/clc-home.adoc
+++ b/docs/modules/ROOT/pages/clc-home.adoc
@@ -28,6 +28,6 @@ Example output:
 
 [source,bash]
 ----
-clc home configs pr-3814
-/home/me/.local/share/clc/configs/pr-3814
+clc home configs prod
+/home/me/.local/share/clc/configs/prod
 ----

--- a/docs/modules/ROOT/pages/clc-job.adoc
+++ b/docs/modules/ROOT/pages/clc-job.adoc
@@ -25,8 +25,7 @@ clc job [command] [options]
 
 Creates a Jet job using the provided Jar file.
 
-This command requires a Viridian or a Hazelcast cluster
-having version 5.3.0-BETA-2 or better.
+This command requires a Hazelcast cluster of 5.3.0-BETA-2 or better.
 
 Usage:
 
@@ -251,9 +250,7 @@ Parameters:
 
 == clc job export-snapshot
 
-Exports a snapshot from a Jet job.
-
-This feature requires a Viridian or Hazelcast Enterprise cluster.
+Exports a snapshot from a Jet job. This feature requires a Hazelcast Enterprise cluster.
 
 Usage:
 

--- a/docs/modules/ROOT/pages/config-wizard.adoc
+++ b/docs/modules/ROOT/pages/config-wizard.adoc
@@ -1,4 +1,4 @@
-== CLC Configuration Wizard
+//== CLC Configuration Wizard
 
 :description: Hazelcast CLC provides a configuration wizard in interactive mode, which allows you to easily manage multiple cluster configurations. The configuration wizard runs when a client connection needs and asks for a single cluster configuration.
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -10,7 +10,7 @@ This file can exist anywhere in the file system, and can be used with the `--con
 clc -c test/config.yaml
 ----
 
-TIP: If you don't add any configuration before and try to run an operation that requires client connection, CLC will prompt a configuration wizard to import Viridian config easily. For details, see xref:config-wizard.adoc[CLC Configuration Wizard ].
+//TIP: If you don't add any configuration before and try to run an operation that requires client connection, CLC will prompt a configuration wizard to import Viridian config easily. For details, see xref:config-wizard.adoc[CLC Configuration Wizard ].
 
 
 If there is a `config.yaml` in the same directory with the CLC binary and the configuration was not explicitly set, CLC tries to load that configuration file:
@@ -36,10 +36,10 @@ Known configurations can be directly specified by their names, instead of the fu
 # List configurations
 $ clc config list
 default
-pr-3066
+prod
 
 # Start CLC shell with configuration named pr-3066
-$ clc -c pr-3066
+$ clc -c prod
 ----
 
 If no configuration is specified, the `default` configuration is used.
@@ -54,7 +54,7 @@ include::partial$global-parameters.adoc[]
 
 == Related Resources
 
-- xref:connect-to-viridian.adoc[].
+//- xref:connect-to-viridian.adoc[].
 
 - xref:connect-to-platform.adoc[].
 

--- a/docs/modules/ROOT/pages/environment-variables.adoc
+++ b/docs/modules/ROOT/pages/environment-variables.adoc
@@ -26,7 +26,7 @@
 |CLC_SKIP_SERVER_VERSION_CHECK
 |Some Hazelcast CLC features require the cluster to be of a certain version. If set to `1`, this variable disables the version check performed by the CLC.
 |`0` (false)
-
+////
 |CLC_VIRIDIAN_API_KEY
 |Sets the {hazelcast-cloud} API key.
 |
@@ -34,7 +34,7 @@
 |CLC_VIRIDIAN_API_SECRET
 |Sets the {hazelcast-cloud} API secret.
 |
-
+////
 |===
 
 The following environment variables are experimental and may be removed in a future version.

--- a/docs/modules/ROOT/pages/overview.adoc
+++ b/docs/modules/ROOT/pages/overview.adoc
@@ -1,6 +1,6 @@
 = Hazelcast Command-Line Client (CLC)
 :url-github-clc: https://github.com/hazelcast/hazelcast-cloud-cli/blob/master/README.md 
-:description: You can use the Hazelcast Command Line Client (CLC) to connect to and interact with clusters on Hazelcast Platform and {hazelcast-cloud}, direct from the command line or through scripts.
+:description: You can use the Hazelcast Command Line Client (CLC) to connect to and interact with clusters on Hazelcast Platform direct from the command line or through scripts.
 
 {description}
 
@@ -18,9 +18,9 @@ Example use cases for the Hazelcast CLC.
 
 Run xref:clc-sql.adoc[SQL] queries against your cluster and display the output as a table or in a variety of text formats, such as JSON and CSV.
 
-=== Manage Viridian Clusters
+//=== Manage Viridian Clusters
 
-xref:clc-viridian.adoc[Create and manage] {hazelcast-cloud} clusters, and the custom classes on those clusters.
+//xref:clc-viridian.adoc[Create and manage] {hazelcast-cloud} clusters, and the custom classes on those clusters.
 
 === Create Data Pipelines
 

--- a/docs/modules/ROOT/pages/release-notes-5.2.0.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.2.0.adoc
@@ -3,7 +3,7 @@
 == New Features
 
 * CLC can now read data serialized using Compact Serialization and Portable automatically.
-* Added the ability to select a configuration from a list or import a Viridian configuration when a configuration is not provided in the shell mode.
+//* Added the ability to select a configuration from a list or import a Viridian configuration when a configuration is not provided in the shell mode.
 * Added the `--quite` (shorthand `-q`) flag which suppresses unnecessary outputs. CLC outputs can be sometimes noisy, such as success message logs; you can use this flag for a more quiet output.
 * Added the `CLC_CLIENT_NAME` environment variable which allows overriding the default client name.
 * Added the `CLC_CLIENT_LABELS` environment variable which allows overriding the default client labels with a comma separated list of labels.
@@ -15,7 +15,7 @@
 ** `object list`: Lists the distributed data structures in the cluster.
 ** `completion`: Generates the autocompletion script for the specified shell, either Bash, Fish, Powershell or Zsh. Use `--help` for more information.
 ** `config add`: Adds configuration to the Hazelcast CLC. For example, to connect to a specific cluster.
-** `config import`: Imports configuration into the Hazelcast CLC from various sources. Currently only the {hazelcast-cloud} Serverless Go Client sample is supported.
+//** `config import`: Imports configuration into the Hazelcast CLC from various sources. Currently only the {hazelcast-cloud} Serverless Go Client sample is supported.
 ** `config list`: Lists known configurations.
 ** `home`: Outputs the Hazelcast CLC home directory, which stores all configuration, logs and other files.
 
@@ -43,7 +43,7 @@
 * Removed `map get-all`, `map put` and `map put-all` commands.
 * Added the `map set` command.
 * Auto-completion is disabled in interactive mode.
-* {hazelcast-cloud} Serverless is the default cloud platform.
+//* {hazelcast-cloud} Serverless is the default cloud platform.
 * The shell connects to the cluster on demand.
 
 == Known issues

--- a/docs/modules/ROOT/pages/release-notes-5.3.0-BETA-1.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.3.0-BETA-1.adoc
@@ -10,7 +10,7 @@
 ** `suspend`: Suspends a job.
 ** `resume`: Resumes a suspended job.
 ** `restart`: Restarts a job.
-** `export-snapshot`: Exports a snapshot for a job. This feature requires a Viridian or Hazelcast Enterprise cluster.
+** `export-snapshot`: Exports a snapshot for a job. This feature requires a Hazelcast Enterprise cluster.
 * Added the following `snapshot` commandS:
 ** `list`: Lists the snapshots of a job.
 ** `delete`: Deletes a snapshot.

--- a/docs/modules/ROOT/pages/release-notes-5.3.0-BETA-2.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.3.0-BETA-2.adoc
@@ -1,7 +1,7 @@
 = 5.3.0-BETA-2 Release Notes
 
 == New Features
-
+////
 * Viridian support. The following commands were added:
 ** `viridian login`
 ** `viridian create-cluster`
@@ -15,6 +15,7 @@
 ** `viridian download-custom-class`
 ** `viridian list-custom-classes`
 ** `viridian upload-custom-class`
+////
 * Added the following new Map commands:
 ** `map key-set`
 ** `map destroy`

--- a/docs/modules/ROOT/pages/release-notes-5.3.0.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.3.0.adoc
@@ -1,7 +1,7 @@
 = 5.3.0 Release Notes
 
 == New Features
-
+////
 * Viridian support. The following commands were added:
 ** `viridian login`
 ** `viridian create-cluster`
@@ -17,6 +17,7 @@
 ** `viridian download-custom-class`
 ** `viridian list-custom-classes`
 ** `viridian upload-custom-class`
+////
 * CLC can now submit Jet jobs and manage job snapshots.
 * Added the following `job` commands:
 ** `submit`: Creates a job from the given jar file.
@@ -25,7 +26,7 @@
 ** `suspend`: Suspends a job.
 ** `resume`: Resumes a suspended job.
 ** `restart`: Restarts a job.
-** `export-snapshot`: Exports a snapshot for a job. This feature requires a Viridian or Hazelcast Enterprise cluster.
+** `export-snapshot`: Exports a snapshot for a job. This feature requires a Hazelcast Enterprise cluster.
 * Added the following `snapshot` commands:
 ** `list`: Lists the snapshots of a job.
 ** `delete`: Deletes a snapshot.
@@ -35,5 +36,5 @@
 
 == Improvements
 
-* Viridian errors are revamped to be more user-friendly.
+//* Viridian errors are revamped to be more user-friendly.
 * Multiline columns are supported in table output.

--- a/docs/modules/ROOT/pages/release-notes-5.3.1.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.3.1.adoc
@@ -8,4 +8,4 @@
 
 * Added a workaround for a server side bug that causes an incorrect hash calculation error when certain type of Jet jars are submitted. See: https://github.com/hazelcast/hazelcast/pull/24674
 * Extended cluster information retrieved from 'clc viridian get-cluster' command.
-* Improved error checking so a token error is displayed when a Viridian command fails with an authentication error.
+//* Improved error checking so a token error is displayed when a Viridian command fails with an authentication error.

--- a/docs/modules/ROOT/pages/upgrade-clc.adoc
+++ b/docs/modules/ROOT/pages/upgrade-clc.adoc
@@ -2,4 +2,4 @@
 
 To upgrade to the latest version, reinstall the Hazelcast CLC after each new release.
 
-For installation options, see xref:install-clc.adoc#installing-hazelcast-clc[].
+For installation options, see xref:install-clc.adoc#installing-hazelcast-clc[Installing the Hazelcast CLC].


### PR DESCRIPTION
Content is hidden rather than removed (checked with Finn). If all change are correct, I will apply to other branches.