### PR TITLE
Fix Project Creator Tests

### DIFF
--- a/base/commands/project/project_create_it_test.go
+++ b/base/commands/project/project_create_it_test.go
@@ -13,9 +13,12 @@ import (
 	"github.com/hazelcast/hazelcast-commandline-client/clc/paths"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/check"
 	"github.com/hazelcast/hazelcast-commandline-client/internal/it"
+	"github.com/hazelcast/hazelcast-commandline-client/internal/it/skip"
 )
 
 func TestCreateCommand(t *testing.T) {
+	// We are skipping this test on Windows, because git-go does not allow to configure core.autocrlf option
+	skip.If(t, "os = windows")
 	os.Setenv(envTemplateSource, "https://github.com/kutluhanmetin")
 	testCases := []struct {
 		inputTemplateName string

--- a/base/commands/project/project_create_it_test.go
+++ b/base/commands/project/project_create_it_test.go
@@ -27,14 +27,17 @@ func TestCreateCommand(t *testing.T) {
 			inputTemplateName: "simple-streaming-pipeline-template",
 			inputOutputDir:    "my-simple-streaming-pipeline",
 			inputArgs:         []string{"rootProjectName=simple-streaming-pipeline"},
-			testProjectDir:    "../../../examples/platform/simple-streaming-pipeline",
+			testProjectDir:    "testdata/simple-streaming-pipeline",
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.inputTemplateName, func(t *testing.T) {
-			defer teardown(tc.inputOutputDir)
 			tcx := it.TestContext{T: t}
 			tcx.Tester(func(tcx it.TestContext) {
+				// create project in temp dir
+				// we cannot initialize it in test case because CLC_HOME is set to a temp dir in tcx.Tester func
+				tc.inputOutputDir = filepath.Join(paths.Home(), tc.inputOutputDir)
+				defer teardown(tc.inputOutputDir)
 				ctx := context.Background()
 				tcx.WithReset(func() {
 					cmd := []string{"project", "create", tc.inputTemplateName, tc.inputOutputDir}

--- a/base/commands/project/testdata/simple-streaming-pipeline/Makefile
+++ b/base/commands/project/testdata/simple-streaming-pipeline/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build
+
+build:
+	./gradlew shadowJar

--- a/base/commands/project/testdata/simple-streaming-pipeline/README.md
+++ b/base/commands/project/testdata/simple-streaming-pipeline/README.md
@@ -1,0 +1,32 @@
+# Simple Streaming Pipeline
+
+Requirements:
+
+1. JRE 8
+2. Gradle 8
+
+## Usage
+
+### Compile the project
+
+```
+gradle shadowJar
+```
+
+### Submit the Jet Job
+
+```
+clc job submit ./build/libs/simple-streaming-pipeline-1.0-SNAPSHOT-all.jar
+```
+
+### Observe the Map Updates
+
+```
+clc map -n my-map entry-set
+```
+
+### Clean Up
+
+```
+clc job cancel ./build/libs/simple-streaming-pipeline-1.0-SNAPSHOT-all.jar
+```

--- a/base/commands/project/testdata/simple-streaming-pipeline/build.gradle
+++ b/base/commands/project/testdata/simple-streaming-pipeline/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
+}
+
+group = 'org.example'
+version = '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compileOnly 'com.hazelcast:hazelcast:5.3.0-BETA-2'
+    implementation 'org.hashids:hashids:1.0.3'
+    testImplementation platform('org.junit:junit-bom:5.9.1')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+jar.manifest.attributes 'Main-Class': 'com.example.SimplePipeline'
+
+compileJava {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+}

--- a/base/commands/project/testdata/simple-streaming-pipeline/settings.gradle
+++ b/base/commands/project/testdata/simple-streaming-pipeline/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'simple-streaming-pipeline'
+

--- a/base/commands/project/testdata/simple-streaming-pipeline/src/main/java/com/example/SimplePipeline.java
+++ b/base/commands/project/testdata/simple-streaming-pipeline/src/main/java/com/example/SimplePipeline.java
@@ -1,0 +1,37 @@
+package com.example;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import com.hazelcast.jet.pipeline.test.TestSources;
+import org.hashids.Hashids;
+
+import java.util.AbstractMap;
+
+public class SimplePipeline {
+    public static void main(String[] args) {
+        final String mapName = (args.length > 0)? args[0] : "my-map";
+        // Create a pipeline that creates one item per second
+        // and writes it to a map with the name given as an argument or my-map.
+        Pipeline pipeline = Pipeline.create();
+        pipeline.readFrom(TestSources.itemStream(1))
+                .withoutTimestamps()
+                .map(e -> new AbstractMap.SimpleEntry<>(
+                        e.sequence(),
+                        new Hashids().encode(e.sequence()))
+                )
+                .writeTo(Sinks.map(mapName,
+                        // Map key is the sequence number
+                        AbstractMap.SimpleEntry::getKey,
+                        // Map value is the hash ID of the sequence
+                        AbstractMap.SimpleEntry::getValue));
+        HazelcastInstance hz = Hazelcast.bootstrappedInstance();
+        JobConfig config = new JobConfig();
+        // optionally set the name of the job
+        config.setName("simple-pipeline");
+        hz.getJet().newJob(pipeline, config);
+    }
+}

--- a/base/commands/sql/common.go
+++ b/base/commands/sql/common.go
@@ -1,3 +1,0 @@
-//go:build std || sql
-
-package sql


### PR DESCRIPTION
- Use `testdata` instead of `examples/platform`.
- Copy templates to the temporary `CLC_HOME` dir.
- Remove unnecessary file `base/commands/sql/common.go`.