### PR TITLE
Ensure config files have the .yaml extension

### DIFF
--- a/clc/paths/paths.go
+++ b/clc/paths/paths.go
@@ -96,7 +96,7 @@ func ResolveConfigPath(path string) string {
 	if path == "" {
 		return path
 	}
-	if filepath.Ext(path) == "" {
+	if filepath.Ext(path) != ".yaml" {
 		path = filepath.Join(Configs(), path, DefaultConfig)
 	}
 	return path


### PR DESCRIPTION
Previously any filename with a dot in it was recognized as full path to the configuration.
This PR changes that and only files with `.yaml` extension are recognized as config files.