### PR TITLE
DOCS-608 Reintroduce Viridian Content and Update Product Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ All paths in the configuration are relative to the parent directory of the confi
   * path: Path to the log file, or `stderr`. By default, the logs are written to `$CLC_HOME/logs` with the current date as the name.
   * level: Log level, one of: `debug`, `info`, `warn`, `error`. The default is `info`.
 
-Here's a sample Viridian Serverless configuration:
+Here's a sample {hazelcast-cloud} Serverless configuration:
 ```
 cluster:
   name: "pr-3814"  

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ All paths in the configuration are relative to the parent directory of the confi
 * cluster
   * name: Name of the cluster. By default `dev`.
   * address: Address of a member in the cluster. By default `localhost:5701`.
-  * discovery-token: Viridian Serverless discovery token.
+  * discovery-token: {hazelcast-cloud} Serverless discovery token.
 
 * ssl
   * ca-path: TLS CA certificate path.

--- a/docs/antora-playbook-local.yml
+++ b/docs/antora-playbook-local.yml
@@ -27,7 +27,7 @@ asciidoc:
     idseparator: '-'
     # Variables used in the docs
     page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9
-    hazelcast-cloud: Viridian
+    hazelcast-cloud: Viridian Cloud
   extensions:
     - ./tabs-block.js
     - asciidoctor-kroki

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -27,7 +27,7 @@ asciidoc:
     idseparator: '-'
     # Variables used in the docs
     page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9
-    hazelcast-cloud: Viridian
+    hazelcast-cloud: Viridian Cloud
   extensions:
     - ./tabs-block.js
     - asciidoctor-kroki

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,17 +1,17 @@
 .Get Started
 * xref:overview.adoc[What is Hazelcast CLC?]
-//* xref:get-started.adoc[Get Started]
-//* Tutorials
-//** xref:managing-viridian-clusters.adoc[Manage Viridian Clusters]
-//** xref:jet-job-management.adoc[Manage Jet Jobs]
+* xref:get-started.adoc[Get Started]
+* Tutorials
+** xref:managing-viridian-clusters.adoc[Manage {hazelcast-cloud} Clusters]
+** xref:jet-job-management.adoc[Manage Jet Jobs]
 
 
 .Manage
 * xref:install-clc.adoc[Install]
 * xref:configuration.adoc[Configure]
-//** xref:connect-to-viridian.adoc[Connect to Viridian]
+** xref:connect-to-viridian.adoc[Connect to {hazelcast-cloud}]
 ** xref:connect-to-platform.adoc[Connect to Platform]
-// ** xref:config-wizard.adoc[CLC Configuration Wizard ]
+** xref:config-wizard.adoc[CLC Configuration Wizard ]
 * xref:upgrade-clc.adoc[Upgrade]
 
 .Reference
@@ -30,7 +30,7 @@
 ** xref:clc-sql.adoc[]
 ** xref:clc-snapshot.adoc[]
 ** xref:clc-version.adoc[]
-//** xref:clc-viridian.adoc[]
+** xref:clc-viridian.adoc[]
 ** xref:clc-project.adoc[]
 * xref:environment-variables.adoc[]
 * xref:keyboard-shortcuts.adoc[]

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -11,7 +11,7 @@
 * xref:configuration.adoc[Configure]
 ** xref:connect-to-viridian.adoc[Connect to {hazelcast-cloud}]
 ** xref:connect-to-platform.adoc[Connect to Platform]
-** xref:config-wizard.adoc[CLC Configuration Wizard ]
+//** xref:config-wizard.adoc[CLC Configuration Wizard ]
 * xref:upgrade-clc.adoc[Upgrade]
 
 .Reference

--- a/docs/modules/ROOT/pages/clc-commands.adoc
+++ b/docs/modules/ROOT/pages/clc-commands.adoc
@@ -53,7 +53,7 @@ include::partial$global-parameters.adoc[]
 |Manage Jet job snapshots.
 
 |xref:clc-viridian.adoc[clc viridian]
-|Viridian related operations.
+|{hazelcast-cloud} related operations.
 
 |xref:clc-object.adoc[clc object]
 |Commands for generic distributed data structures.

--- a/docs/modules/ROOT/pages/clc-config.adoc
+++ b/docs/modules/ROOT/pages/clc-config.adoc
@@ -56,37 +56,37 @@ Configuration keys:
 |cluster.discovery-token
 |Any string
 |
-|Viridian only
+|{hazelcast-cloud} only
 
 |ssl.enabled
 |true / false
 |false
-|Viridian or Hazelcast Enterprise
+|{hazelcast-cloud} or Hazelcast Enterprise
 
 |ssl.server
 |DOMAIN_NAME (must match SSL certificate)
 |
-|Viridian (automatically set) or Hazelcast Enterprise
+|{hazelcast-cloud} (automatically set) or Hazelcast Enterprise
 
 |ssl.skip-verify
 |true / false
 |false
-|Viridian or Hazelcast Enterprise. Disables SSL host name and client-side verification. Never set to true in production.
+|{hazelcast-cloud} or Hazelcast Enterprise. Disables SSL host name and client-side verification. Never set to true in production.
 
 |ssl.ca-path
 |An absolute or relative path
 |
-|Viridian or Hazelcast Enterprise. Sets the path to the CA certificate.
+|{hazelcast-cloud} or Hazelcast Enterprise. Sets the path to the CA certificate.
 
 |ssl.key-path
 |An absolute or relative path
 |
-|Viridian or Hazelcast Enterprise. Sets the path to the certificate key.
+|{hazelcast-cloud} or Hazelcast Enterprise. Sets the path to the certificate key.
 
 |ssl.key-password
-|Any sring
+|Any string
 |
-|Viridian or Hazelcast Enterprise. Sets the passwor the certificate key.
+|{hazelcast-cloud} or Hazelcast Enterprise. Sets the password for the certificate key.
 
 |log.path
 |An absolute or relative path or `stderr` to log to stderr.

--- a/docs/modules/ROOT/pages/clc-home.adoc
+++ b/docs/modules/ROOT/pages/clc-home.adoc
@@ -28,6 +28,6 @@ Example output:
 
 [source,bash]
 ----
-clc home configs prod
-/home/me/.local/share/clc/configs/prod
+clc home configs pr-3814
+/home/me/.local/share/clc/configs/pr-3814
 ----

--- a/docs/modules/ROOT/pages/clc-job.adoc
+++ b/docs/modules/ROOT/pages/clc-job.adoc
@@ -25,7 +25,7 @@ clc job [command] [options]
 
 Creates a Jet job using the provided Jar file.
 
-This command requires a Hazelcast cluster of 5.3.0-BETA-2 or better.
+This command requires a {hazelcast-cloud} or Hazelcast cluster of 5.3.0-BETA-2 or better.
 
 Usage:
 
@@ -250,7 +250,7 @@ Parameters:
 
 == clc job export-snapshot
 
-Exports a snapshot from a Jet job. This feature requires a Hazelcast Enterprise cluster.
+Exports a snapshot from a Jet job. This feature requires a {hazelcast-cloud} or Hazelcast Enterprise cluster.
 
 Usage:
 

--- a/docs/modules/ROOT/pages/clc-job.adoc
+++ b/docs/modules/ROOT/pages/clc-job.adoc
@@ -25,7 +25,7 @@ clc job [command] [options]
 
 Creates a Jet job using the provided Jar file.
 
-This command requires a {hazelcast-cloud} or Hazelcast cluster of 5.3.0-BETA-2 or better.
+This command requires a {hazelcast-cloud} or Hazelcast cluster of version 5.3.0 or above.
 
 Usage:
 

--- a/docs/modules/ROOT/pages/clc-viridian.adoc
+++ b/docs/modules/ROOT/pages/clc-viridian.adoc
@@ -1,8 +1,8 @@
 = clc viridian
 
-This command group provides commands for doing various Viridian operations, such as creating and managing clusters.
+This command group provides commands for doing various {hazelcast-cloud} operations, such as creating and managing clusters.
 
-All commands except `viridian login` requires  a token to be generated using an API key and secret which can be retrieved from Viridian Console. Running `viridian login` prompts this information, and creates and saves the token.
+All commands except `viridian login` require the generation of a token using an API key and secret, which you can retrieve from {hazelcast-cloud} console. Running `viridian login` prompts you for this information, and creates and saves the token.
 
 Usage:
 
@@ -31,7 +31,7 @@ clc viridian [command] [options]
 
 == clc viridian login
 
-Logs in to Viridian using the given API key and API secret and retrieves a token.
+Logs in to {hazelcast-cloud} using the given API key and API secret and retrieves a token.
 The token is cached to be used by other commands.
 If not specified, the key and the secret will be asked in a prompt.
 
@@ -67,9 +67,9 @@ Parameters:
 
 == clc viridian list-cluster-types
 
-Lists available cluster types that can be used while creating a Viridian cluster.
+Lists available cluster types that can be used while creating a {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate with the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -93,9 +93,9 @@ Parameters:
 
 == clc viridian create-cluster
 
-Creates a Viridian cluster.
+Creates a {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -129,9 +129,9 @@ Parameters:
 
 == clc viridian get-cluster
 
-Gets the information about the given Viridian cluster.
+Gets the information about the given {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -155,9 +155,9 @@ Parameters:
 
 == clc viridian list-clusters
 
-Lists all Viridian clusters for the logged in API key.
+Lists all {hazelcast-cloud} clusters for the logged in API key.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -181,9 +181,9 @@ Parameters:
 
 == clc viridian stop-cluster
 
-Stops the given Viridian cluster.
+Stops the given {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -207,9 +207,9 @@ Parameters:
 
 == clc viridian resume-cluster
 
-Resumes the given Viridian cluster.
+Resumes the given {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -233,9 +233,9 @@ Parameters:
 
 == clc viridian delete-cluster
 
-Deletes the given Viridian cluster. Note that, all data in the cluster is deleted irreversibly.
+Deletes the given {hazelcast-cloud} cluster. Note that, all data in the cluster is deleted irreversibly.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -264,9 +264,9 @@ Parameters:
 
 == clc viridian download-logs
 
-Downloads the logs of the given Viridian cluster.
+Downloads the logs of the given {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -295,9 +295,9 @@ Parameters:
 
 == clc viridian stream-logs
 
-Outputs the logs of the given Viridian cluster as a stream.
+Outputs the logs of the given {hazelcast-cloud} cluster as a stream.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 The log format may be one of:
 
@@ -333,9 +333,9 @@ Parameters:
 
 == clc viridian import-config
 
-Imports connection configuration of the given Viridian cluster.
+Imports connection configuration of the given {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -359,9 +359,9 @@ Parameters:
 
 == clc viridian list-custom-classes
 
-Lists all custom classes in the Viridian cluster.
+Lists all custom classes in the {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -385,9 +385,9 @@ Parameters:
 
 == clc viridian upload-custom-class
 
-Uploads a custom class to the Viridian cluster.
+Uploads a custom class to the {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -398,9 +398,9 @@ clc viridian upload-custom-class [cluster-name/cluster-ID] [file-name] [flags]
 
 == clc viridian download-custom-class
 
-Downloads a custom class from the Viridian cluster.
+Downloads a custom class from the {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 
@@ -424,9 +424,9 @@ Parameters:
 
 == clc viridian delete-custom-class
 
-Deletes a custom class from the Viridian cluster.
+Deletes a custom class from the {hazelcast-cloud} cluster.
 
-Make sure you authenticate to the Viridian API using `viridian login` before running this command.
+Make sure you authenticate to the {hazelcast-cloud} API using `viridian login` before running this command.
 
 Usage:
 

--- a/docs/modules/ROOT/pages/clc-viridian.adoc
+++ b/docs/modules/ROOT/pages/clc-viridian.adoc
@@ -2,7 +2,7 @@
 
 This command group provides commands for doing various {hazelcast-cloud} operations, such as creating and managing clusters.
 
-All commands except `viridian login` require the generation of a token using an API key and secret, which you can retrieve from {hazelcast-cloud} console. Running `viridian login` prompts you for this information, and creates and saves the token.
+All commands except `viridian login` require the generation of a token using an API key and secret, which you can retrieve from the {hazelcast-cloud} console. Running `viridian login` prompts you for this information, and creates and saves the token.
 
 Usage:
 

--- a/docs/modules/ROOT/pages/config-wizard.adoc
+++ b/docs/modules/ROOT/pages/config-wizard.adoc
@@ -1,4 +1,4 @@
-//== CLC Configuration Wizard
+== CLC Configuration Wizard
 
 :description: Hazelcast CLC provides a configuration wizard in interactive mode, which allows you to easily manage multiple cluster configurations. The configuration wizard runs when a client connection needs and asks for a single cluster configuration.
 
@@ -6,11 +6,11 @@
 
 {description}
 
-If you don't have any configuration yet, it will show a prompt screen to enter a configuration source with target name. If you have configurations
-in the Hazelcast CLC home directory, it will list them and ask for you to select one to create client connection.
+If you try to run an operation that requires a client connection before you have added any configuration, you are prompted to enter a configuration source with the target name. 
 
-TIP: If you have a configuration named `default`, a configuration YAML exists next to executable or in the current working directory,
-CLC directly uses it instead of running configuration wizard.
+If you have already added one or more configurations to the Hazelcast CLC home directory, you are prompted to select one to create a client connection.
+
+TIP: If you have a configuration named `default`, a configuration YAML exists next to the executable or in the current working directory. CLC uses this instead of running configuration wizard.
 
 == Before you Begin
 
@@ -40,7 +40,7 @@ input screen for you to import a new configuration.
 +
 ```bash
 There is no configuration detected. You can register a new configuration to conn
-You can connect to Viridian cluster using curl request from `Dashboard -> Connec
+You can connect to {hazelcast-cloud} cluster using curl request from `Dashboard -> Connec
 Paste the link to source field below and it will download the config and TLS fil
 
 Configuration Name: default
@@ -60,14 +60,13 @@ Configuration Name: default
 
 . Copy the Go Client sample url from {hazelcast-cloud} console.
 
-. Paste the Go client sample CURL request link to `Source: ` in this screen.
+. Paste the Go client sample CURL request link to `Source:` in this screen.
 +
 ```bash
 Source: curl https://api.viridian.hazelcast.com/client_samples/download/...
 ```
 +
-. Press `[ Submit ]` and it will automatically connect to your Viridian cluster. Notice that if you didn't specify the
-configuration name or leave it as default, it will automatically connect to this client unless you specify it with `--config` flag.
+. Press `[ Submit ]` and it will automatically connect to your Viridian Cloud cluster. Notice that if you didn't specify the configuration name or leave it as default, it will automatically connect to this client unless you specify it with `--config` flag.
 
 == Multiple Configurations
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -10,8 +10,7 @@ This file can exist anywhere in the file system, and can be used with the `--con
 clc -c test/config.yaml
 ----
 
-//TIP: If you don't add any configuration before and try to run an operation that requires client connection, CLC will prompt a configuration wizard to import Viridian config easily. For details, see xref:config-wizard.adoc[CLC Configuration Wizard ].
-
+TIP: If you try to run an operation that requires a client connection before you have added any configuration, CLC will prompt the configuration wizard to import a {hazelcast-cloud} configuration. For details, see xref:config-wizard.adoc[CLC Configuration Wizard].
 
 If there is a `config.yaml` in the same directory with the CLC binary and the configuration was not explicitly set, CLC tries to load that configuration file:
 [source, bash]
@@ -36,10 +35,10 @@ Known configurations can be directly specified by their names, instead of the fu
 # List configurations
 $ clc config list
 default
-prod
+pr-3066
 
 # Start CLC shell with configuration named pr-3066
-$ clc -c prod
+$ clc -c pr-3066
 ----
 
 If no configuration is specified, the `default` configuration is used.
@@ -54,7 +53,7 @@ include::partial$global-parameters.adoc[]
 
 == Related Resources
 
-//- xref:connect-to-viridian.adoc[].
+- xref:connect-to-viridian.adoc[Connecting to {hazelcast-cloud} with Hazelcast CLC].
 
-- xref:connect-to-platform.adoc[].
+- xref:connect-to-platform.adoc[Connecting to Hazelcast Platform with Hazelcast CLC].
 

--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -10,7 +10,7 @@ This file can exist anywhere in the file system, and can be used with the `--con
 clc -c test/config.yaml
 ----
 
-TIP: If you try to run an operation that requires a client connection before you have added any configuration, CLC will prompt the configuration wizard to import a {hazelcast-cloud} configuration. For details, see xref:config-wizard.adoc[CLC Configuration Wizard].
+//TIP: If you try to run an operation that requires a client connection before you have added any configuration, CLC will prompt the configuration wizard to import a {hazelcast-cloud} configuration. For details, see xref:config-wizard.adoc[CLC Configuration Wizard].
 
 If there is a `config.yaml` in the same directory with the CLC binary and the configuration was not explicitly set, CLC tries to load that configuration file:
 [source, bash]

--- a/docs/modules/ROOT/pages/connect-to-viridian.adoc
+++ b/docs/modules/ROOT/pages/connect-to-viridian.adoc
@@ -29,7 +29,7 @@ clc viridian login
 [[list-accessible-clusters]]
 == List Accessible Clusters
 
-Run the following command to list the clusters linked to your Hazelcast {hazelcast-cloud} account:
+Run the following command to list the clusters linked to your {hazelcast-cloud} account:
 
 ```bash
 clc viridian list-clusters

--- a/docs/modules/ROOT/pages/environment-variables.adoc
+++ b/docs/modules/ROOT/pages/environment-variables.adoc
@@ -27,6 +27,14 @@
 |Some Hazelcast CLC features require the cluster to be of a certain version. If set to `1`, this variable disables the version check performed by the CLC.
 |`0` (false)
 
+|CLC_VIRIDIAN_API_KEY
+|Sets the {hazelcast-cloud} API key.
+|
+
+|CLC_VIRIDIAN_API_SECRET
+|Sets the {hazelcast-cloud} API secret.
+|
+
 |CLC_CONFIG
 |Sets the configuration CLC will use if `--config` flag is not specified.
 |

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -1,5 +1,5 @@
 = Get Started With the Hazelcast CLC
-:description: In this tutorial, you'll learn the basics of how to configure the Hazelcast CLC, start it, and connect it to a Hazelcast {hazelcast-cloud} Serverless development cluster and a Serverless production cluster. You'll also see how to switch between clusters, using the Hazelcast CLC. Finally, you'll perform some basic operations on a cluster from the command line and then by running a script to automate the same actions.
+:description: In this tutorial, you'll learn how to use Hazelcast CLC commands to authenticate with Hazelcast {hazelcast-cloud} and create two production clusters. You'll connect to and switch between clusters from the command line. Finally, you'll perform some basic operations on a cluster from both the command line and by running a script to automate the same actions.
 
 {description}
 
@@ -7,183 +7,141 @@
 
 You need the following:
 
-- The xref:install-clc.adoc[Hazelcast CLC] installed on your local machine
-- Two xref:cloud:ROOT:create-serverless-cluster.adoc[Hazelcast {hazelcast-cloud} Serverless clusters]. For this tutorial, you'll use one development and one production cluster, to show how you might use the CLC for basic administration and deployment tasks.
+- xref:install-clc.adoc[Hazelcast CLC] installed on your local machine.
+- xref:cloud:ROOT:developer.adoc[{hazelcast-cloud} API key and secret]
 
-TIP: You can download Go client samples from Hazelcast {hazelcast-cloud} console. For details, see xref:cloud:ROOT:connect-to-cluster.adoc[].
+== Step 1. Authenticating with {hazelcast-cloud}
 
-[[step-1-dev-configure]]
-== Step 1. Add Configuration for the Development Cluster
+To allow the Hazelcast CLC to to interact with {hazelcast-cloud} clusters, you must generate a {hazelcast-cloud} token.
 
-Make sure that your {hazelcast-cloud} development cluster is running before you start.
-
-The Hazelcast CLC can use a Go client sample for {hazelcast-cloud} to discover the configuration for your {hazelcast-cloud} cluster.
-
-. Download the Go client sample for your development cluster from the {hazelcast-cloud} console.
-Once the sample is downloaded, you can use the `clc config import` command to import the configuration.
-
-. From the command line, execute the following command, replacing `PATH-TO-SAMPLE.zip` with the path to the downloaded sample:
-
+. Execute the following command to retrieve the {hazelcast-cloud} token.
 +
-[source, bash]
+[source,shell]
 ----
-clc config import dev PATH-TO-SAMPLE.zip
-clc -c dev
+clc viridian login
 ----
 
+. When prompted, enter your API key and secret. If both are correct, the token is retrieved and saved.
+
+== Step 2. Create Two {hazelcast-cloud} Clusters
+
+In this step, you'll create two production clusters called Test1 and Test2 from the command line, and run some commands to check their status.
+
+. Execute the following command to create your first production cluster.
 +
-. You can use the `clc config list` command to confirm that the configuration was imported. The output will look something like this:
+[source,shell]
+----
+clc viridian create-cluster --name Test1
+----
 +
-[source, bash]
-----
-clc config list
-default
-dev
-----
+Wait while the cluster is created and the cluster configuration is imported into the Hazelcast CLC.
+
+. Create your second production cluster in the same way.
 
 +
-. The CLC only connects to the cluster when necessary. Run a command that requires a connection to the cluster, such as `object list`:
+[source,shell]
+----
+clc viridian create-cluster --name Test2
+----
 
+. Try running the following command to check your clusters have been created:
 +
-[source, clc]
+[source,shell]
+----
+clc viridian list-clusters
+----
++
+The details of all clusters linked to your Hazelcast {hazelcast-cloud} account are returned, including the Cluster ID, Cluster Name, Current Status, Hazelcast Version.
+
+
+[[step-2-prod-configure]]
+== Step 2. Add Configuration to Connect to {hazelcast-cloud}
+
+To connect to each production cluster, you need to import additional cluster configuration from {hazelcast-cloud}. 
+
+. link:https://viridian.hazelcast.com/[Sign in to {hazelcast-cloud}] and select your Test1 cluster.
+
+. From the cluster dashboard, click *CLI* to open the *Quick Connection Guide* for the Hazelcast CLC client.
+
+. Run the `clc config import` command in step 2. This command updates the cluster configuration on your local machine.
+
+. Run the `clc -c pr-<CLUSTER_ID>` command in step 3 to connect to your cluster using the Hazelcast CLC.
+
+. The Hazelcast CLC only connects to the cluster when necessary. Run a command that requires a connection to the cluster, such as `object list`:
++
+[source, shell]
 ----
 CLC> \object list
-Connected to cluster: pr-3814
+Connected to cluster: pr-<CLUSTER-ID>
 ----
-
 +
 As this is a new cluster, no objects are returned.
 
-+
-. Press kbd:[Ctrl+D] or type `\exit` to shut down the Hazelcast CLC while you complete the configuration for your production cluster.
+. Press kbd:[Ctrl+D] or type `\exit` to shut down the Hazelcast CLC while you complete the configuration of your second production cluster.
 
-[[step-2-prod-configure]]
-== Step 2. Add Configuration for the Production Cluster
-
-The configuration of the production cluster is the same as the previous step, but using the production cluster configuration.
-
-Make sure that your {hazelcast-cloud} production cluster is running before you start.
-
-. Download the Go client sample for your production cluster from the {hazelcast-cloud} console.
-. From the command line, execute the following command, replacing `PATH-TO-SAMPLE.zip` with the path to the downloaded sample:
-
-+
-[source, bash]
-----
-clc config import prod PATH-TO-SAMPLE.zip
-clc -c prod
-----
-
-+
-. CLC only connects to the cluster when necessary.
-Run a command that requires a connection to the cluster, such as `object list`:
-
-+
-[source, clc]
-----
-CLC> \object list
-Connected to cluster: pr-3690
-
-------------------------------------
- Service Name | Object Name
-------------------------------------
- executor     | hot-backup-executor
-------------------------------------
-----
+. Repeat steps 2 to 7 for Test2.
 
 [[step-3-cluster-switch]]
 == Step 3. Switch Between Clusters
 
-Having separate local configurations for your development and production clusters allows you to switch between them without leaving the command line. Make sure both clusters are running before you start.
+Having separate local configurations for your two production clusters allows you to switch between them without leaving the command line. Make sure both clusters are running before you start.
 
-. Execute the following command to use the `dev` configuration to connect to your development cluster:
+. Execute the following command to use the local configuration to connect to your Test1 cluster. Replace the placeholder `$CLUSTER_ID` with the ID of your cluster. 
 +
-[source, bash]
+[source, shell]
 ----
-clc -c dev
+clc -c pr-$CLUSTER_ID
 ----
 
 +
-As before, the Hazelcast CLC connects to your development cluster.
+As before, the Hazelcast CLC connects to your Test1 cluster.
 . Type `\exit` to return to the command line.
-. Execute the following command to use the new configuration file for your production cluster.
+. Execute the same command to connect to Test2, using the ID of this cluster.
 +
-[source, bash]
+[source, shell]
 ----
-clc -c prod
+clc -c pr-$CLUSTER_ID
 ----
 +
-The Hazelcast CLC shell is started, using the configuration for the production cluster. You can exit the shell by typing `\exit`.
+. Again, type `\exit` to return to the command line.
 
 [[step-4-write-data]]
 == Step 4. Write Data to a Map
 
-Now that you've connected to both your clusters, try using the Hazelcast CLC to write data to a map on your development cluster.
-Let's write a script that adds some data to a map.
+Now that you've connected to both your clusters, try using the Hazelcast CLC to create a map on Test1, write some data to it, and query the data. You can use SQL to do this.
 
-. Create a file called `data.script` on your local machine and copy in the following lines.
-+
-.data.script
-[source]
-----
-\map set -n currency -k i32 1 -v json '{"Code": "CAD", "Currency": "Canadian Dollar"}'
-\map set -n currency -k i32 2 -v json '{"Code": "INR", "Currency": "Indian Rupee"}'
-\map set -n currency -k i32 3 -v json '{"Code": "MXN", "Currency": "Mexican Peso"}'
-\map set -n currency -k i32 4 -v json '{"Code": "GBP", "Currency": "Pounds Sterling"}'
-\map set -n currency -k i32 5 -v json '{"Code": "TRY", "Currency": "Turkish Lira"}'
-\map set -n currency -k i32 6 -v json '{"Code": "USD", "Currency": "United States Dollar"}'
-----
-
-. Run the script in the `data.script` file to update the `currency` map:
-+
-On Linux and MacOS:
-+
-[source,bash]
-----
-cat data.script | clc -c dev
-----
-+
-On Windows:
-+
-[source,bash]
-----
-type data.script | clc -c dev
-----
-
-
-Do a quick check on your cluster to make sure that your data has been written successfully.
-
-. Open the dashboard of the development cluster and click *Management Center*.
-. Go to *Storage* > *Maps*. You'll see that your cluster has a map called `currency` with six entries. 
-
-[[step-5-query-map]]
-== Step 5. Query Map Data
-You can use SQL to query the data in your `currency` map.
-
-. Start by creating a mapping to the `currency` map.
+. Start by creating a mapping to a new `currency`` map. As before replace the placeholder value `$CLUSTER_ID` in all commands.
 
 +
-[source,bash]
+[source,shell]
 ----
-clc sql -c dev "CREATE OR REPLACE MAPPING currency (__key INT, Code VARCHAR, Currency VARCHAR) TYPE IMap OPTIONS('keyFormat'='int', 'valueFormat'='json-flat')"
+clc sql -c pr-$CLUSTER_ID "CREATE OR REPLACE MAPPING currency (__key INT, Code VARCHAR, Currency VARCHAR) TYPE IMap OPTIONS('keyFormat'='int', 'valueFormat'='json-flat');"
 ----
++
 The SQL mapping statement does a number of things:
 
 ** Adds column headings for currencies and codes
 ** Creates a SQL connection to the map
 ** Tells Hazelcast how to serialize and deserialize the keys and values.
 
+. Add some data to the map.
++
+[source,shell]
+----
+clc sql -c pr-$CLUSTER_ID "INSERT INTO currency VALUES (1, 'CAD','Canadian Dollar'),(2, 'INR','Indian Rupee'),(3, 'MXN', 'Mexican Peso'),(4, 'GBP', 'Pounds Sterling'),(5, 'TRY', 'Turkish Lira'),(6, 'USD', 'United States Dollar');"
+----
+
 . Try running some simple queries against the `currency` map. For example, this query returns all data in the map and orders it by the currency code.  
 +
-[source,bash]
+[source,shell]
 ----
-clc sql -c dev "SELECT * FROM currency ORDER BY Code" -f table
+clc sql -c pr-$CLUSTER_ID "SELECT * FROM currency ORDER BY Code" -f table
 ----
 +
 The results look like this:
 
 +
-[source,shell]
+[source,sql]
 ----
 --------------------------------------------------------------------------------
       __key | Code                            | Currency
@@ -202,7 +160,7 @@ The results look like this:
 
 When you're ready, combine the commands that you've learned about so far into a script and run them from the command line.
 
-The script first writes the currency data to a new map called `currencydata` on your development server, queries it and then switches to your production cluster to perform the same actions.
+The script writes the currency data to a new map called `currencydata` on a cluster and queries it.
 
 . Copy the following commands into a script.
 +
@@ -237,47 +195,55 @@ SELECT * FROM currencydata ORDER BY Code;
 Linux and MacOS::
 + 
 --
-. To run the script on your development cluster, execute the following command:
+. To run the script on your Test1 cluster, execute the following command replacing the placeholder $CLUSTER_ID:
 +
-[source,bash]
+[source,shell]
 ----
-cat myscript.sql | clc -c dev
+cat myscript.sql | clc -c pr-$CLUSTER_ID
 ----
 +
-. Then, to run the script on your production cluster, execute the following command:
+. Then, to run the script on your Test2 cluster, execute the same command using the ID of this cluster.
 +
-[source,bash]
+[source,shell]
 ----
-cat myscript.sql | clc -c prod
+cat myscript.sql | clc -c pr-$CLUSTER_ID
 ----
 
 --
 Windows::
 +
 --
-. To run the script on your development cluster, execute the following command:
+. To run the script on your Test1 cluster, execute the following command replacing the placeholder $CLUSTER_ID:
 +
-[source,bash]
+[source,shell]
 ----
-type myscript.sql | clc -c dev
+type myscript.sql | clc -c pr-$CLUSTER_ID
 ----
 +
-. Then, to run the script on your production cluster, execute the following command:
+. Then, to run the script on your Test2 cluster, execute the same command using the ID of this cluster.
 +
-[source,bash]
+[source,shell]
 ----
-type myscript.sql | clc -c prod
+type myscript.sql | clc -c pr-$CLUSTER_ID
 ----
 
 --
 ====
 
+== Step 5. Clean Up
+
+To delete both test clusters from your account.
+
+. link:https://viridian.hazelcast.com/[Sign in to {hazelcast-cloud}] and select a test cluster.
+. Click *Delete* and confirm your deletion.
+
 == Summary
 
 In this tutorial, you learned how to do the following:
 
-* Connect to a Hazelcast {hazelcast-cloud} Serverless development cluster.
-* Connect to a Hazelcast {hazelcast-cloud} Serverless production cluster.
+* Authenticate with {hazelcast-cloud}.
+* Create a cluster and check its status.
+* Connect to a {hazelcast-cloud} production cluster.
 * Switch between clusters from the command line.
 * Write data to a map and query the data using SQL.
 * Automate commands by running a sequence of actions from a shell script.
@@ -291,4 +257,8 @@ Use these resources to continue learning:
 - xref:clc-commands.adoc[].
 
 - xref:clc-sql.adoc[].
+
+- xref:managing-viridian-clusters.adoc[]
+
+- xref:jet-job-management.adoc[]
 

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -55,7 +55,7 @@ The details of all clusters linked to your Hazelcast {hazelcast-cloud} account a
 
 
 [[step-2-prod-configure]]
-== Step 2. Add Configuration to Connect to {hazelcast-cloud}
+== Step 3. Add Configuration to Connect to {hazelcast-cloud}
 
 To connect to each production cluster, you need to import additional cluster configuration from {hazelcast-cloud}. 
 
@@ -92,19 +92,20 @@ NOTE: This command shows the cluster ID prefixed with `pr` instead of the cluste
 . Repeat steps 1 to 4 for Test2.
 
 [[step-3-cluster-switch]]
-== Step 3. Switch Between Clusters
+== Step 4. Switch Between Clusters
 
 Having separate local configurations for your two production clusters allows you to switch between them without leaving the command line. Make sure both clusters are running before you start.
 
 . Execute the following command to connect to your Test1 cluster.
 
++
 [source, shell]
 ----
 clc -c Test1
 ----
-
 +
 As before, the Hazelcast CLC connects to your Test1 cluster.
+
 . Type `\exit` to return to the command line.
 . Execute the same command to connect to Test2.
 +
@@ -112,11 +113,10 @@ As before, the Hazelcast CLC connects to your Test1 cluster.
 ----
 clc -c Test2
 ----
-+
 . Again, type `\exit` to return to the command line.
 
 [[step-4-write-data]]
-== Step 4. Write Data to a Map
+== Step 5. Write Data to a Map
 
 Now that you've connected to both your clusters, try using the Hazelcast CLC to create a map on Test1, write some data to it, and query the data. You can use SQL to do this.
 
@@ -240,7 +240,7 @@ type myscript.sql | clc -c Test2
 --
 ====
 
-== Step 5. Clean Up
+== Step 7. Clean Up
 
 To delete both test clusters from your account.
 

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -86,7 +86,7 @@ As this is a new cluster, no objects are returned.
 
 Having separate local configurations for your two production clusters allows you to switch between them without leaving the command line. Make sure both clusters are running before you start.
 
-. Execute the following command to use the local configuration to connect to your Test1 cluster. Replace the placeholder `$CLUSTER_ID` with the ID of your cluster. 
+. Execute the following command to use the imported configuration to connect to your Test1 cluster. Replace the placeholder `$CLUSTER_ID` with the ID of your cluster. 
 +
 [source, shell]
 ----

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -59,13 +59,21 @@ The details of all clusters linked to your Hazelcast {hazelcast-cloud} account a
 
 To connect to each production cluster, you need to import additional cluster configuration from {hazelcast-cloud}. 
 
-. link:https://viridian.hazelcast.com/[Sign in to {hazelcast-cloud}] and select your Test1 cluster.
+. Run the `clc config import` to update the cluster configuration on your local machine.
 
-. From the cluster dashboard, click *CLI* to open the *Quick Connection Guide* for the Hazelcast CLC client.
++
+[source, shell]
+----
+clc viridian import-config Test1
+----
 
-. Run the `clc config import` command in step 2. This command updates the cluster configuration on your local machine.
+. Run the following command to connect to your cluster using the Hazelcast CLC.
 
-. Run the `clc -c pr-<CLUSTER_ID>` command in step 3 to connect to your cluster using the Hazelcast CLC.
++
+[source, shell]
+----
+clc -c Test1
+----
 
 . The Hazelcast CLC only connects to the cluster when necessary. Run a command that requires a connection to the cluster, such as `object list`:
 +
@@ -76,31 +84,33 @@ Connected to cluster: pr-<CLUSTER-ID>
 ----
 +
 As this is a new cluster, no objects are returned.
++
+NOTE: This command shows the cluster ID prefixed with `pr` instead of the cluster name. You can see the cluster ID in *Cluster Details* on the {hazelcast-cloud} console.
 
 . Press kbd:[Ctrl+D] or type `\exit` to shut down the Hazelcast CLC while you complete the configuration of your second production cluster.
 
-. Repeat steps 2 to 7 for Test2.
+. Repeat steps 1 to 4 for Test2.
 
 [[step-3-cluster-switch]]
 == Step 3. Switch Between Clusters
 
 Having separate local configurations for your two production clusters allows you to switch between them without leaving the command line. Make sure both clusters are running before you start.
 
-. Execute the following command to use the imported configuration to connect to your Test1 cluster. Replace the placeholder `$CLUSTER_ID` with the ID of your cluster. 
-+
+. Execute the following command to connect to your Test1 cluster.
+
 [source, shell]
 ----
-clc -c pr-$CLUSTER_ID
+clc -c Test1
 ----
 
 +
 As before, the Hazelcast CLC connects to your Test1 cluster.
 . Type `\exit` to return to the command line.
-. Execute the same command to connect to Test2, using the ID of this cluster.
+. Execute the same command to connect to Test2.
 +
 [source, shell]
 ----
-clc -c pr-$CLUSTER_ID
+clc -c Test2
 ----
 +
 . Again, type `\exit` to return to the command line.
@@ -110,12 +120,12 @@ clc -c pr-$CLUSTER_ID
 
 Now that you've connected to both your clusters, try using the Hazelcast CLC to create a map on Test1, write some data to it, and query the data. You can use SQL to do this.
 
-. Start by creating a mapping to a new `currency`` map. As before replace the placeholder value `$CLUSTER_ID` in all commands.
+. Start by creating a mapping to a new `currency` map. 
 
 +
 [source,shell]
 ----
-clc sql -c pr-$CLUSTER_ID "CREATE OR REPLACE MAPPING currency (__key INT, Code VARCHAR, Currency VARCHAR) TYPE IMap OPTIONS('keyFormat'='int', 'valueFormat'='json-flat');"
+clc sql -c Test1 "CREATE OR REPLACE MAPPING currency (__key INT, Code VARCHAR, Currency VARCHAR) TYPE IMap OPTIONS('keyFormat'='int', 'valueFormat'='json-flat');"
 ----
 +
 The SQL mapping statement does a number of things:
@@ -128,14 +138,14 @@ The SQL mapping statement does a number of things:
 +
 [source,shell]
 ----
-clc sql -c pr-$CLUSTER_ID "INSERT INTO currency VALUES (1, 'CAD','Canadian Dollar'),(2, 'INR','Indian Rupee'),(3, 'MXN', 'Mexican Peso'),(4, 'GBP', 'Pounds Sterling'),(5, 'TRY', 'Turkish Lira'),(6, 'USD', 'United States Dollar');"
+clc sql -c Test1 "INSERT INTO currency VALUES (1, 'CAD','Canadian Dollar'),(2, 'INR','Indian Rupee'),(3, 'MXN', 'Mexican Peso'),(4, 'GBP', 'Pounds Sterling'),(5, 'TRY', 'Turkish Lira'),(6, 'USD', 'United States Dollar');"
 ----
 
 . Try running some simple queries against the `currency` map. For example, this query returns all data in the map and orders it by the currency code.  
 +
 [source,shell]
 ----
-clc sql -c pr-$CLUSTER_ID "SELECT * FROM currency ORDER BY Code" -f table
+clc sql -c Test1 "SELECT * FROM currency ORDER BY Code" -f table
 ----
 +
 The results look like this:
@@ -195,36 +205,36 @@ SELECT * FROM currencydata ORDER BY Code;
 Linux and MacOS::
 + 
 --
-. To run the script on your Test1 cluster, execute the following command replacing the placeholder $CLUSTER_ID:
+. To run the script on your Test1 cluster, execute the following command.
 +
 [source,shell]
 ----
-cat myscript.sql | clc -c pr-$CLUSTER_ID
+cat myscript.sql | clc -c Test1
 ----
 +
-. Then, to run the script on your Test2 cluster, execute the same command using the ID of this cluster.
+. Then, to run the script on your Test2 cluster, execute the same command replacing the cluster name.
 +
 [source,shell]
 ----
-cat myscript.sql | clc -c pr-$CLUSTER_ID
+cat myscript.sql | clc -c Test2
 ----
 
 --
 Windows::
 +
 --
-. To run the script on your Test1 cluster, execute the following command replacing the placeholder $CLUSTER_ID:
+. To run the script on your Test1 cluster, execute the following command.
 +
 [source,shell]
 ----
-type myscript.sql | clc -c pr-$CLUSTER_ID
+type myscript.sql | clc -c Test1
 ----
 +
-. Then, to run the script on your Test2 cluster, execute the same command using the ID of this cluster.
+. Then, to run the script on your Test2 cluster, execute the same command replacing the cluster name.
 +
 [source,shell]
 ----
-type myscript.sql | clc -c pr-$CLUSTER_ID
+type myscript.sql | clc -c Test2
 ----
 
 --

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -15,11 +15,11 @@ TIP: You can download Go client samples from Hazelcast {hazelcast-cloud} console
 [[step-1-dev-configure]]
 == Step 1. Add Configuration for the Development Cluster
 
-Make sure that your Viridian development cluster is running before you start.
+Make sure that your {hazelcast-cloud} development cluster is running before you start.
 
-The Hazelcast CLC can use a Go client sample for Viridian to discover the configuration for your Viridian cluster.
+The Hazelcast CLC can use a Go client sample for {hazelcast-cloud} to discover the configuration for your {hazelcast-cloud} cluster.
 
-. Download the Go client sample for your development cluster from the Viridian console.
+. Download the Go client sample for your development cluster from the {hazelcast-cloud} console.
 Once the sample is downloaded, you can use the `clc config import` command to import the configuration.
 
 . From the command line, execute the following command, replacing `PATH-TO-SAMPLE.zip` with the path to the downloaded sample:
@@ -62,9 +62,9 @@ As this is a new cluster, no objects are returned.
 
 The configuration of the production cluster is the same as the previous step, but using the production cluster configuration.
 
-Make sure that your Viridian production cluster is running before you start.
+Make sure that your {hazelcast-cloud} production cluster is running before you start.
 
-. Download the Go client sample for your production cluster from the Viridian console.
+. Download the Go client sample for your production cluster from the {hazelcast-cloud} console.
 . From the command line, execute the following command, replacing `PATH-TO-SAMPLE.zip` with the path to the downloaded sample:
 
 +

--- a/docs/modules/ROOT/pages/jet-job-management.adoc
+++ b/docs/modules/ROOT/pages/jet-job-management.adoc
@@ -14,7 +14,7 @@ You need the following:
 - Gradle 8 or above.
 
 [[step-1-authenticating-with-viridian]]
-== Step 1. Authenticating with Viridian
+== Step 1. Authenticating with {hazelcast-cloud}
 
 To allow the Hazelcast CLC to perform cluster operations, including submitting Jet jobs, you must generate a {hazelcast-cloud} token.
 

--- a/docs/modules/ROOT/pages/managing-viridian-clusters.adoc
+++ b/docs/modules/ROOT/pages/managing-viridian-clusters.adoc
@@ -13,9 +13,9 @@ You need the following:
 - xref:cloud:ROOT:developer.adoc[{hazelcast-cloud} API key and secret]
 
 [[step-1-authenticating-with-viridian]]
-== Step 1. Authenticating with Viridian
+== Step 1. Authenticating with {hazelcast-cloud}
 
-To allow the Hazelcast CLC to perform cluster operations, you must generate a Viridian token.
+To allow the Hazelcast CLC to perform cluster operations, you must generate a {hazelcast-cloud} token.
 
 . Execute the following command to retrieve the {hazelcast-cloud} token. 
 +
@@ -60,7 +60,7 @@ To check that the `my-cluster` is up and running, use the following command.
 ----
 clc viridian list-clusters
 ----
-The details of all clusters linked to your Hazelcast {hazelcast-cloud} account are returned, including the Cluster ID, Cluster Name, Current Status, Hazelcast Version.
+The details of all clusters linked to your {hazelcast-cloud} account are returned, including the Cluster ID, Cluster Name, Current Status, Hazelcast Version.
 
 [source, bash, subs="attributes+"]
 ----

--- a/docs/modules/ROOT/pages/overview.adoc
+++ b/docs/modules/ROOT/pages/overview.adoc
@@ -1,6 +1,6 @@
 = Hazelcast Command-Line Client (CLC)
 :url-github-clc: https://github.com/hazelcast/hazelcast-cloud-cli/blob/master/README.md 
-:description: You can use the Hazelcast Command Line Client (CLC) to connect to and interact with clusters on Hazelcast Platform direct from the command line or through scripts.
+:description: You can use the Hazelcast Command Line Client (CLC) to connect to and interact with clusters on {hazelcast-cloud} and Hazelcast Platform direct from the command line or through scripts.
 
 {description}
 
@@ -18,9 +18,9 @@ Example use cases for the Hazelcast CLC.
 
 Run xref:clc-sql.adoc[SQL] queries against your cluster and display the output as a table or in a variety of text formats, such as JSON and CSV.
 
-//=== Manage Viridian Clusters
+=== Manage {hazelcast-cloud} Clusters
 
-//xref:clc-viridian.adoc[Create and manage] {hazelcast-cloud} clusters, and the custom classes on those clusters.
+xref:clc-viridian.adoc[Create and manage] {hazelcast-cloud} clusters, and the custom classes on those clusters.
 
 === Create Data Pipelines
 

--- a/docs/modules/ROOT/pages/release-notes-5.2.0.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.2.0.adoc
@@ -15,7 +15,6 @@
 ** `object list`: Lists the distributed data structures in the cluster.
 ** `completion`: Generates the autocompletion script for the specified shell, either Bash, Fish, Powershell or Zsh. Use `--help` for more information.
 ** `config add`: Adds configuration to the Hazelcast CLC. For example, to connect to a specific cluster.
-** `config import`: Imports configuration into the Hazelcast CLC from various sources. Currently only the {hazelcast-cloud} Serverless Go Client sample is supported.
 ** `config list`: Lists known configurations.
 ** `home`: Outputs the Hazelcast CLC home directory, which stores all configuration, logs and other files.
 

--- a/docs/modules/ROOT/pages/release-notes-5.2.0.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.2.0.adoc
@@ -3,19 +3,19 @@
 == New Features
 
 * CLC can now read data serialized using Compact Serialization and Portable automatically.
-//* Added the ability to select a configuration from a list or import a Viridian configuration when a configuration is not provided in the shell mode.
+* Added the ability to select a configuration from a list or import a {hazelcast-cloud} configuration when a configuration is not provided in the shell mode.
 * Added the `--quite` (shorthand `-q`) flag which suppresses unnecessary outputs. CLC outputs can be sometimes noisy, such as success message logs; you can use this flag for a more quiet output.
 * Added the `CLC_CLIENT_NAME` environment variable which allows overriding the default client name.
 * Added the `CLC_CLIENT_LABELS` environment variable which allows overriding the default client labels with a comma separated list of labels.
 
-* Added support for link:https://hazelcast.com/products/viridian/[Hazelcast {hazelcast-cloud} Serverless].
+* Added support for link:https://hazelcast.com/products/viridian/[{hazelcast-cloud} Serverless].
 
 * Added the following commands:
 
 ** `object list`: Lists the distributed data structures in the cluster.
 ** `completion`: Generates the autocompletion script for the specified shell, either Bash, Fish, Powershell or Zsh. Use `--help` for more information.
 ** `config add`: Adds configuration to the Hazelcast CLC. For example, to connect to a specific cluster.
-//** `config import`: Imports configuration into the Hazelcast CLC from various sources. Currently only the {hazelcast-cloud} Serverless Go Client sample is supported.
+** `config import`: Imports configuration into the Hazelcast CLC from various sources. Currently only the {hazelcast-cloud} Serverless Go Client sample is supported.
 ** `config list`: Lists known configurations.
 ** `home`: Outputs the Hazelcast CLC home directory, which stores all configuration, logs and other files.
 
@@ -43,7 +43,7 @@
 * Removed `map get-all`, `map put` and `map put-all` commands.
 * Added the `map set` command.
 * Auto-completion is disabled in interactive mode.
-//* {hazelcast-cloud} Serverless is the default cloud platform.
+* {hazelcast-cloud} Serverless is the default cloud platform.
 * The shell connects to the cluster on demand.
 
 == Known issues

--- a/docs/modules/ROOT/pages/release-notes-5.3.0-BETA-1.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.3.0-BETA-1.adoc
@@ -10,7 +10,7 @@
 ** `suspend`: Suspends a job.
 ** `resume`: Resumes a suspended job.
 ** `restart`: Restarts a job.
-** `export-snapshot`: Exports a snapshot for a job. This feature requires a Hazelcast Enterprise cluster.
+** `export-snapshot`: Exports a snapshot for a job. This feature requires a {hazelcast-cloud} or Hazelcast Enterprise cluster.
 * Added the following `snapshot` commandS:
 ** `list`: Lists the snapshots of a job.
 ** `delete`: Deletes a snapshot.

--- a/docs/modules/ROOT/pages/release-notes-5.3.0-BETA-2.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.3.0-BETA-2.adoc
@@ -1,8 +1,8 @@
 = 5.3.0-BETA-2 Release Notes
 
 == New Features
-////
-* Viridian support. The following commands were added:
+
+* {hazelcast-cloud} support. The following commands were added:
 ** `viridian login`
 ** `viridian create-cluster`
 ** `viridian delete-cluster`
@@ -15,7 +15,6 @@
 ** `viridian download-custom-class`
 ** `viridian list-custom-classes`
 ** `viridian upload-custom-class`
-////
 * Added the following new Map commands:
 ** `map key-set`
 ** `map destroy`

--- a/docs/modules/ROOT/pages/release-notes-5.3.0.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.3.0.adoc
@@ -1,8 +1,7 @@
 = 5.3.0 Release Notes
 
 == New Features
-////
-* Viridian support. The following commands were added:
+* {hazelcast-cloud} support. The following commands were added:
 ** `viridian login`
 ** `viridian create-cluster`
 ** `viridian delete-cluster`
@@ -17,7 +16,6 @@
 ** `viridian download-custom-class`
 ** `viridian list-custom-classes`
 ** `viridian upload-custom-class`
-////
 * CLC can now submit Jet jobs and manage job snapshots.
 * Added the following `job` commands:
 ** `submit`: Creates a job from the given jar file.
@@ -26,7 +24,7 @@
 ** `suspend`: Suspends a job.
 ** `resume`: Resumes a suspended job.
 ** `restart`: Restarts a job.
-** `export-snapshot`: Exports a snapshot for a job. This feature requires a Hazelcast Enterprise cluster.
+** `export-snapshot`: Exports a snapshot for a job. This feature requires a {hazelcast-cloud} or Hazelcast Enterprise cluster.
 * Added the following `snapshot` commands:
 ** `list`: Lists the snapshots of a job.
 ** `delete`: Deletes a snapshot.
@@ -36,5 +34,5 @@
 
 == Improvements
 
-//* Viridian errors are revamped to be more user-friendly.
+* {hazelcast-cloud} errors are revamped to be more user-friendly.
 * Multiline columns are supported in table output.

--- a/docs/modules/ROOT/pages/release-notes-5.3.1.adoc
+++ b/docs/modules/ROOT/pages/release-notes-5.3.1.adoc
@@ -8,4 +8,4 @@
 
 * Added a workaround for a server side bug that causes an incorrect hash calculation error when certain type of Jet jars are submitted. See: https://github.com/hazelcast/hazelcast/pull/24674
 * Extended cluster information retrieved from 'clc viridian get-cluster' command.
-//* Improved error checking so a token error is displayed when a Viridian command fails with an authentication error.
+* Improved error checking so a token error is displayed when a {hazelcast-cloud} command fails with an authentication error.


### PR DESCRIPTION
Reintroduces hidden Viridian content and updates product name to Viridian Cloud in line with new branding. Once this PR is approved I can update previous versions 5.3.x and 5.2.x with the same changes.

**Outstanding question:**

On both the configuration page (configuration.adoc) and in Get Started (get-started.adoc) we mention downloading the sample Go client to discover a Viridian cloud cluster. Not sure if an alternative to this has been planned.

