### PR TITLE
Fix loading access token when the API key is given explicitly

### DIFF
--- a/base/commands/viridian/common.go
+++ b/base/commands/viridian/common.go
@@ -29,19 +29,19 @@ var (
 	ErrLoadingSecrets = errors.New("could not load Viridian secrets, did you login?")
 )
 
-func findToken(apiKey string) (string, error) {
+func findTokenPath(apiKey string) (string, error) {
 	ac := viridian.APIClass()
 	if apiKey == "" {
 		apiKey = os.Getenv(viridian.EnvAPIKey)
 	}
 	if apiKey != "" {
-		return fmt.Sprintf("%s-%s", ac, apiKey), nil
+		return fmt.Sprintf(secrets.TokenFileFormat, ac, apiKey), nil
 	}
 	tokenPaths, err := findAll(secretPrefix)
 	if err != nil {
 		return "", fmt.Errorf("cannot access the secrets, did you login?: %w", err)
 	}
-	// sort tokens, so findToken returns the same token everytime.
+	// sort tokens, so findTokenPath returns the same token everytime.
 	sort.Slice(tokenPaths, func(i, j int) bool {
 		return tokenPaths[i] < tokenPaths[j]
 	})
@@ -75,7 +75,7 @@ func findKeyAndSecret(tokenPath string) (string, string, error) {
 }
 
 func getAPI(ec plug.ExecContext) (*viridian.API, error) {
-	tp, err := findToken(ec.Props().GetString(propAPIKey))
+	tp, err := findTokenPath(ec.Props().GetString(propAPIKey))
 	if err != nil {
 		return nil, err
 	}

--- a/base/commands/viridian/common_test.go
+++ b/base/commands/viridian/common_test.go
@@ -31,10 +31,10 @@ func TestFindToken(t *testing.T) {
 			// check the token filename for the first API key is returned if the API key was not specified
 			require.Equal(t, "api-APIKEY1.access", check.MustValue(findTokenPath("")))
 			// check the token filename for the given API key is returned
-			require.Equal(t, "api-APIKEY2.access", check.MustValue(findTokenPath("APIKEY2.access")))
+			require.Equal(t, "api-APIKEY2.access", check.MustValue(findTokenPath("APIKEY2")))
 			// check the token filename for the given API class is returned
 			it.WithEnv(viridian.EnvAPI, "cls", func() {
-				require.Equal(t, "cls-CLSKEY1.access", check.MustValue(findTokenPath("CLSKEY1.access")))
+				require.Equal(t, "cls-CLSKEY1.access", check.MustValue(findTokenPath("CLSKEY1")))
 			})
 		})
 	})

--- a/base/commands/viridian/common_test.go
+++ b/base/commands/viridian/common_test.go
@@ -22,19 +22,19 @@ func TestFindToken(t *testing.T) {
 	it.WithEnv(paths.EnvCLCHome, home.Path(), func() {
 		it.WithEnv(viridian.EnvAPIKey, "", func() {
 			// should return an error if there are no secrets
-			_, err := findToken("")
+			_, err := findTokenPath("")
 			require.Error(t, err)
 			// fixture
 			check.Must(secrets.Write(prefix, "api-APIKEY1.access", []byte("token-APIKEY1")))
 			check.Must(secrets.Write(prefix, "api-APIKEY2.access", []byte("token-APIKEY2")))
 			check.Must(secrets.Write(prefix, "cls-CLSKEY1.access", []byte("token-CLSKEY1")))
 			// check the token filename for the first API key is returned if the API key was not specified
-			require.Equal(t, "api-APIKEY1.access", check.MustValue(findToken("")))
+			require.Equal(t, "api-APIKEY1.access", check.MustValue(findTokenPath("")))
 			// check the token filename for the given API key is returned
-			require.Equal(t, "api-APIKEY2.access", check.MustValue(findToken("APIKEY2.access")))
+			require.Equal(t, "api-APIKEY2.access", check.MustValue(findTokenPath("APIKEY2.access")))
 			// check the token filename for the given API class is returned
 			it.WithEnv(viridian.EnvAPI, "cls", func() {
-				require.Equal(t, "cls-CLSKEY1.access", check.MustValue(findToken("CLSKEY1.access")))
+				require.Equal(t, "cls-CLSKEY1.access", check.MustValue(findTokenPath("CLSKEY1.access")))
 			})
 		})
 	})

--- a/clc/secrets/secrets.go
+++ b/clc/secrets/secrets.go
@@ -59,9 +59,3 @@ func Read(prefix, name string) ([]byte, error) {
 	}
 	return b[:n], nil
 }
-
-func FindAll(prefix string) ([]string, error) {
-	return paths.FindAll(paths.Join(paths.Secrets(), prefix), func(basePath string, entry os.DirEntry) (ok bool) {
-		return !entry.IsDir() && filepath.Ext(entry.Name()) == filepath.Ext(TokenFileFormat)
-	})
-}


### PR DESCRIPTION
Fixes getting the access token path when `--api-key` or `CLC_VIRIDIAN_API_KEY` is used