### PR TITLE
DOCS-568 Text changes for consistent renaming to Viridian Cloud v2

### DIFF
--- a/docs/check-links-playbook.yml
+++ b/docs/check-links-playbook.yml
@@ -32,7 +32,7 @@ asciidoc:
     # Separate anchor link names by dashes
     idseparator: '-'
     page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9
-    hazelcast-cloud: Hazelcast Viridian
+    hazelcast-cloud: Viridian Cloud
   extensions:
     - ./tabs-block.js
     - asciidoctor-kroki

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -5,7 +5,7 @@
 .Manage
 * xref:install-clc.adoc[Install]
 * xref:configuration.adoc[Configure]
-** xref:connect-to-viridian.adoc[Connect to Viridian]
+** xref:connect-to-viridian.adoc[Connect to Viridian Cloud]
 ** xref:connect-to-platform.adoc[Connect to Platform]
 //** xref:config-wizard.adoc[CLC Configuration Wizard ]
 * xref:upgrade-clc.adoc[Upgrade]

--- a/docs/modules/ROOT/pages/clc-config.adoc
+++ b/docs/modules/ROOT/pages/clc-config.adoc
@@ -135,9 +135,9 @@ clc config add dev cluster.name=dev cluster.address=localhost:5701
 
 Imports configuration from an arbitrary source.
 
-Currently importing only Viridian connection configuration is supported.
+Currently importing only {hazelcast-cloud} connection configuration is supported.
 
-1. On Viridian console, visit:
+1. On the {hazelcast-cloud} console, visit:
 +
 Dashboard -> Connect Client -> Quick connection guide -> Go
 
@@ -145,10 +145,6 @@ Dashboard -> Connect Client -> Quick connection guide -> Go
 Make sure the text is quoted before running:
 +
 	clc config import my-config "curl https://api.viridian.hazelcast.com ... default.zip"
-+
-Alternatively, you can use an already downloaded Go client sample:
-+
-	clc config import my-config /home/me/Downloads/hazelcast-cloud-go-sample....zip
 
 Usage:
 
@@ -172,8 +168,8 @@ Parameters:
 |Required
 |The following configuration sources are supported:
 
-* Zip file for the Viridian Go client, e.g., `hazelcast-cloud-go-sample-client-pr-3814-default.zip`. Use this if you have downloaded the sample yourself.
-* cURL command line for the Viridian Go client sample, such as: `curl https://api.viridian.hazelcast.com/client_samples/download/XXX -o hazelcast-cloud-go-sample-client-pr-3814-default.zip`. Use this command to allow the Hazelcast CLC to download the sample. Do not forget to wrap the line with quotes.
+* Zip file for the {hazelcast-cloud} Go client, e.g., `hazelcast-cloud-go-sample-client-pr-3814-default.zip`. Use this if you have downloaded the sample yourself.
+* cURL command line for the {hazelcast-cloud} Go client sample, such as: `curl https://api.viridian.hazelcast.com/client_samples/download/XXX -o hazelcast-cloud-go-sample-client-pr-3814-default.zip`. Use this command to allow the Hazelcast CLC to download the sample. Do not forget to wrap the line with quotes.
 
 |N/A
 

--- a/docs/modules/ROOT/pages/connect-to-viridian.adoc
+++ b/docs/modules/ROOT/pages/connect-to-viridian.adoc
@@ -1,5 +1,5 @@
-== Connecting to {hazelcast-cloud} with Hazelcast CLC
-:description: To use the Hazelcast CLC with {hazelcast-cloud}, you can download a preconfigured client. You don’t need to do any configuration.
+== Connecting to Hazelcast {hazelcast-cloud} with Hazelcast CLC
+:description: To use the Hazelcast CLC with Hazelcast {hazelcast-cloud}, you can download a preconfigured client. You don't need to do any configuration.
 
 :page-product: cloud
 
@@ -14,7 +14,7 @@ You need the following:
 - Hazelcast CLC
 - A {hazelcast-cloud} cluster
 
-TIP: You can find all connection credentials such as the cluster name and discovery token in the {hazelcast-cloud} console. For details, see xref:cloud:ROOT:connect-to-cluster.adoc[].
+TIP: You can find all connection credentials, such as the cluster name and discovery token, in the {hazelcast-cloud} console. For details, see xref:cloud:ROOT:connect-to-cluster.adoc[].
 
 [[mutual]]
 == Connecting to Clusters

--- a/docs/modules/ROOT/pages/get-started.adoc
+++ b/docs/modules/ROOT/pages/get-started.adoc
@@ -1,5 +1,5 @@
 = Get Started With the Hazelcast CLC
-:description: In this tutorial, you'll learn the basics of how to configure the Hazelcast CLC, start it, and connect it to a {hazelcast-cloud} cluster. You'll also see how to switch between clusters, using the Hazelcast CLC. Finally, you'll perform some basic operations on a cluster from the command line and then by running a script to automate the same actions.
+:description: In this tutorial, you'll learn the basics of how to configure the Hazelcast CLC, start it, and connect it to a cluster on Hazelcast {hazelcast-cloud}. You'll also see how to switch between clusters, using the Hazelcast CLC. Finally, you'll perform some basic operations on a cluster from the command line and then by running a script to automate the same actions.
 
 {description}
 
@@ -8,13 +8,13 @@
 You need the following:
 
 - The xref:install-clc.adoc[Hazelcast CLC] installed on your local machine
-- Two xref:cloud:ROOT:create-serverless-cluster.adoc[Hazelcast {hazelcast-cloud} clusters]. For this tutorial, you'll use one development and one production cluster, to show how you might use the CLC for basic administration and deployment tasks.
+- Two xref:cloud:ROOT:create-serverless-cluster.adoc[{hazelcast-cloud} clusters]. For this tutorial, you'll use one development and one production cluster, to show how you might use the CLC for basic administration and deployment tasks.
 
 
 [[step-1-dev-configure]]
 == Step 1. Add Configuration for the Development Cluster
 
-Make sure that your {hazelcast-cloud} development cluster is running before you start.
+Make sure that your development cluster is running before you start.
 
 . link:https://viridian.hazelcast.com/[Sign in to {hazelcast-cloud}] and select the development cluster.
 
@@ -54,7 +54,7 @@ As this is a new cluster, no objects are returned.
 
 The configuration of the production cluster is the same as the previous step, but using the production cluster configuration.
 
-Make sure that your {hazelcast-cloud} production cluster is running before you start.
+Make sure that your production cluster is running before you start.
 
 . link:https://viridian.hazelcast.com/[Sign in to {hazelcast-cloud}] and select the production cluster.
 
@@ -250,8 +250,8 @@ To delete both test clusters from your account.
 
 In this tutorial, you learned how to do the following:
 
-* Connect to a Hazelcast {hazelcast-cloud} Serverless development cluster.
-* Connect to a Hazelcast {hazelcast-cloud} Serverless production cluster.
+* Connect to a development cluster on {hazelcast-cloud}.
+* Connect to a production cluster on {hazelcast-cloud}.
 * Switch between clusters from the command line.
 * Write data to a map and query the data using SQL.
 * Automate commands by running a sequence of actions from a shell script.

--- a/docs/modules/ROOT/pages/install-clc.adoc
+++ b/docs/modules/ROOT/pages/install-clc.adoc
@@ -192,7 +192,7 @@ Windows::
 . Right-click on it and select *Uninstall*.
 . Press kbd:[Yes] on the uninstallation dialog.
 
-Release Packagae::
+Release Package::
 +
 Delete the `hazelcast-commandline-client` directory.
 ====

--- a/docs/modules/ROOT/pages/overview.adoc
+++ b/docs/modules/ROOT/pages/overview.adoc
@@ -1,6 +1,6 @@
 = Hazelcast Command-Line Client (CLC)
 :url-github-clc: https://github.com/hazelcast/hazelcast-cloud-cli/blob/master/README.md 
-:description: You can use the Hazelcast Command Line Client (CLC) to connect to and interact with clusters on Hazelcast Platform, direct from the command line or through scripts.
+:description: You can use the Hazelcast Command Line Client (CLC) to connect to and interact with clusters on Hazelcast {hazelcast-cloud} and Hazelcast Platform, direct from the command line or through scripts.
 
 {description}
 

--- a/docs/modules/ROOT/pages/release-notes.adoc
+++ b/docs/modules/ROOT/pages/release-notes.adoc
@@ -2,13 +2,13 @@
 
 == New Features
 
-* CLC can now read data serialized using Compact Serialization and Portable automatically.
-* Added the ability to select a configuration from a list or import a Viridian configuration when a configuration is not provided in the shell mode.
+* Hazelcast CLC can now automatically read data serialized using compact and portable serialization.
+* Added the ability to select a configuration from a list or import a {hazelcast-cloud} configuration when a configuration is not provided in the shell mode.
 * Added the `--quite` (shorthand `-q`) flag which suppresses unnecessary outputs. CLC outputs can be sometimes noisy, such as success message logs; you can use this flag for a more quiet output.
 * Added the `CLC_CLIENT_NAME` environment variable which allows overriding the default client name.
 * Added the `CLC_CLIENT_LABElS` environment variable which allows overriding the default client labels with a comma separated list of labels.
 
-* Added support for link:https://hazelcast.com/products/viridian/[Hazelcast {hazelcast-cloud} Serverless].
+* Added support for link:https://hazelcast.com/products/viridian/[Hazelcast {hazelcast-cloud} Standard].
 
 * Added the following commands:
 
@@ -42,7 +42,7 @@
 * Removed `map get-all`, `map put` and `map put-all` commands.
 * Added the `map set` command.
 * Auto-completion is disabled in interactive mode.
-* {hazelcast-cloud} Serverless is the default cloud platform.
+* {hazelcast-cloud} Standard is the default cloud platform.
 * The shell connects to the cluster on demand.
 
 == Known issues


### PR DESCRIPTION
Minor text updates for consistent use Viridian Cloud as new product name for Hazelcast Viridian.