### PR TITLE
Fixed unmarshalling error when IP Allowlist is configured on viridian

### DIFF
--- a/internal/viridian/types.go
+++ b/internal/viridian/types.go
@@ -18,7 +18,7 @@ type Cluster struct {
 	HotRestartEnabled  bool         `json:"hotRestartEnabled"`
 	PlanName           string       `json:"planName"`
 	Regions            []Region     `json:"regions"`
-	AllowedIps         []string     `json:"allowedIps"`
+	AllowedIps         []IP         `json:"allowedIps"`
 	IPWhitelistEnabled bool         `json:"ipWhitelistEnabled"`
 	MaxAvailableMemory int          `json:"maxAvailableMemory"`
 }
@@ -43,4 +43,10 @@ type ClusterType struct {
 
 type Region struct {
 	Title string `json:"title"`
+}
+
+type IP struct {
+	ID          int    `json:"id"`
+	IP          string `json:"ip"`
+	Description string `json:"description",omitempty`
 }


### PR DESCRIPTION
Here's the log message from `clc viridian list-clusters` when a cluster has an IP Allow list configured

```
2023-08-11T19:47:32.962+0100    ERROR   viridian/common.go:228  listing clusters: json: cannot unmarshal array into Go struct field Cluster.Content.allowedIps of type string
```

Here's an example of what the IP looks like from the Viridian `/cluster/` endpoint - grabbed from the Viridian UI
{id: 177, ip: "207.154.227.247", description: null}