### PR TITLE
[CLC-432]: Fix hanging problem when source and target clusters is not running

### DIFF
--- a/base/commands/migration/migration_stages.go
+++ b/base/commands/migration/migration_stages.go
@@ -200,6 +200,9 @@ func saveReportToFile(ctx context.Context, ci *hazelcast.ClientInternal, migrati
 
 func WaitForMigrationToBeInProgress(ctx context.Context, ci *hazelcast.ClientInternal, migrationID string) error {
 	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		status, err := fetchMigrationStatus(ctx, ci, migrationID)
 		if err != nil {
 			if errors.Is(err, migrationStatusNotFoundErr) {


### PR DESCRIPTION
- The reason of the problem is that we forgot to handle context errors in for loop while waiting migration to be in progress, so even if we have a timeout error it waits for it to be in progress forever.
- Also this PR increases the timeout of the context, because it was 30 seconds which is same with the backend. So sometimes it used to fail with timeout, sometimes with `Unable to connect to any cluster` error. After increasing the timeout, user will consistently see the `Unable to connect to any cluster` error.